### PR TITLE
 workload: teminates insertion for SIGTERM

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -265,6 +265,14 @@ func (c *core) DoInsert(ctx context.Context, db ycsb.DB) error {
 			break
 		}
 
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
+		default:
+		}
+
 		// Retry if configured. Without retrying, the load process will fail
 		// even if one single insertion fails. User can optionally configure
 		// an insertion retry limit (default is 0) to enable retry.


### PR DESCRIPTION
The program doesn't terminate after receiving SIGTERM(ctrl+C).

```
^C
Got signal [interrupt] to exit.
2018/04/18 09:50:01 Close session with [meta, 127.0.1.1:34601]
2018/04/18 09:50:01 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:01 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:01 Close session with [meta, 127.0.1.1:34602]
2018/04/18 09:50:01 Close session with [meta, 127.0.1.1:34603]
2018/04/18 09:50:01 Close session with [replica, 10.231.58.225:34805]
2018/04/18 09:50:01 failed to read response from [10.231.58.225:34805, replica]: read tcp 10.231.58.225:60286->10.231.58.225:34805: use of closed network connection
2018/04/18 09:50:01 Close session with [replica, 10.231.58.225:34802]
2018/04/18 09:50:01 failed to read response from [10.231.58.225:34802, replica]: read tcp 10.231.58.225:44268->10.231.58.225:34802: use of closed network connection
2018/04/18 09:50:01 Close session with [replica, 10.231.58.225:34804]
2018/04/18 09:50:01 failed to read response from [10.231.58.225:34804, replica]: read tcp 10.231.58.225:48558->10.231.58.225:34804: use of closed network connection
2018/04/18 09:50:01 Close session with [replica, 10.231.58.225:34803]
2018/04/18 09:50:01 failed to read response from [10.231.58.225:34803, replica]: read tcp 10.231.58.225:33038->10.231.58.225:34803: use of closed network connection
2018/04/18 09:50:03 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:04 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:06 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:07 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:09 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
2018/04/18 09:50:10 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:3}), replica(10.231.58.225:34802)]
```

As we didn't configure `insertionRetryLimit`, `DoInsert` repeatedly failed due to context canceled.
It's expected to exit the loop, but it runs infinitely so we have to use `kill -9` to kill the process.

After this commit, the program can successfully exit:

```
^C
Got signal [interrupt] to exit.
2018/04/18 10:27:49 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:7}), replica(10.231.58.225:34803)]
2018/04/18 10:27:49 pegasus-go-client SET failed: [ERR_CLIENT_FAILED] context canceled [Gpid({Appid:1 PartitionIndex:0}), replica(10.231.58.225:34802)]
2018/04/18 10:27:49 querying configuration of table(temp) from [127.0.1.1:34601, meta]
Run finished, takes 1.222950286s
INSERT - Count: 8202, Avg(us): 271, Min(us): 178, Max(us): 23469, 95th(us): 1000, 99th(us): 1000
2018/04/18 10:27:49 Close session with [meta, 127.0.1.1:34601]
2018/04/18 10:27:49 failed to query configuration from meta 127.0.1.1:34601: context canceled
2018/04/18 10:27:49 querying configuration of table(temp) from [127.0.1.1:34602, meta]
2018/04/18 10:27:49 Close session with [meta, 127.0.1.1:34602]
2018/04/18 10:27:49 failed to query configuration from meta 127.0.1.1:34602: context canceled
2018/04/18 10:27:49 querying configuration of table(temp) from [127.0.1.1:34603, meta]
2018/04/18 10:27:49 Close session with [meta, 127.0.1.1:34603]
2018/04/18 10:27:49 failed to query configuration from meta 127.0.1.1:34603: context canceled
2018/04/18 10:27:49 self update failed [table: temp]: failed to connect table(temp): context canceled
2018/04/18 10:27:49 Close session with [replica, 10.231.58.225:34802]
2018/04/18 10:27:49 failed to read response from [10.231.58.225:34802, replica]: read tcp 10.231.58.225:44534->10.231.58.225:34802: use of closed network connection
2018/04/18 10:27:49 Close session with [replica, 10.231.58.225:34804]
2018/04/18 10:27:49 failed to read response from [10.231.58.225:34804, replica]: read tcp 10.231.58.225:48822->10.231.58.225:34804: use of closed network connection
2018/04/18 10:27:49 Close session with [replica, 10.231.58.225:34803]
2018/04/18 10:27:49 failed to read response from [10.231.58.225:34803, replica]: read tcp 10.231.58.225:33304->10.231.58.225:34803: use of closed network connection
2018/04/18 10:27:49 Close session with [replica, 10.231.58.225:34805]
2018/04/18 10:27:49 failed to read response from [10.231.58.225:34805, replica]: read tcp 10.231.58.225:60552->10.231.58.225:34805: use of closed network connection
```