### PR TITLE
Fix bug in Hash64, which causes problems in ScrambledZipfian

### DIFF
--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -24,7 +24,11 @@ func Hash64(n int64) int64 {
 	binary.BigEndian.PutUint64(b[0:8], uint64(n))
 	hash := fnv.New64a()
 	hash.Write(b[0:8])
-	return int64(hash.Sum64())
+	result := int64(hash.Sum64())
+	if result < 0 {
+		return -result
+	}
+	return result
 }
 
 // BytesHash64 returns the fnv hash of a bytes


### PR DESCRIPTION
I believe there is a bug in the implementation of `Hash64`, which causes problems in the ScrambledZipfian generator. In the original YCSB, the output of `fnvhash64` is guaranteed to be a positive number (see https://github.com/brianfrankcooper/YCSB/blob/master/core/src/main/java/com/yahoo/ycsb/Utils.java#L64). However, in go-ycsb, the output could be negative, which could cause ScrambledZipfian to return out-of-bounds values (see https://github.com/pingcap/go-ycsb/blob/master/pkg/generator/scrambled_zipfian.go#L73).

This pull request fixes the issue by adding the absolute value operation in the output of `Hash64`, analogously to what is done in YCSB's `fnvhash64`.