### PR TITLE
Support the batch mode in load stage ( just for tikv)

### DIFF
--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -43,15 +43,6 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		if cmd.Flags().Changed("target") {
 			globalProps.Set(prop.Target, strconv.Itoa(targetArg))
 		}
-
-		if cmd.Flags().Changed("batchMode") {
-			globalProps.Set(prop.DoBatch, strconv.FormatBool(batchMode))
-		}
-
-		if cmd.Flags().Changed("batchSize") {
-			globalProps.Set(prop.BatchSize, strconv.Itoa(int(batchSize)))
-		}
-
 	})
 
 	fmt.Println("***************** properties *****************")
@@ -97,8 +88,6 @@ func runTransCommandFunc(cmd *cobra.Command, args []string) {
 var (
 	threadsArg int
 	targetArg  int
-	batchMode  bool
-	batchSize  uint32
 )
 
 func initClientCommand(m *cobra.Command) {
@@ -107,11 +96,6 @@ func initClientCommand(m *cobra.Command) {
 	m.Flags().StringVar(&tableName, "table", "", "Use the table name instead of the default \""+prop.TableNameDefault+"\"")
 	m.Flags().IntVar(&threadsArg, "threads", 1, "Execute using n threads - can also be specified as the \"threadcount\" property")
 	m.Flags().IntVar(&targetArg, "target", 0, "Attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
-}
-
-func loadModeCommand(m *cobra.Command) {
-	m.Flags().BoolVar(&batchMode, "batchMode", false, "Use the batch mode in workload, just the tikv support the batch mode")
-	m.Flags().Uint32Var(&batchSize, "batchSize", 16, "The size of batch in batch mode (default: 16)")
 }
 
 func newLoadCommand() *cobra.Command {
@@ -123,7 +107,6 @@ func newLoadCommand() *cobra.Command {
 	}
 
 	initClientCommand(m)
-	loadModeCommand(m)
 	return m
 }
 

--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -43,6 +43,15 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		if cmd.Flags().Changed("target") {
 			globalProps.Set(prop.Target, strconv.Itoa(targetArg))
 		}
+
+		if cmd.Flags().Changed("batchMode") {
+			globalProps.Set(prop.DoBatch, strconv.FormatBool(batchMode))
+		}
+
+		if cmd.Flags().Changed("batchSize") {
+			globalProps.Set(prop.BatchSize, strconv.Itoa(int(batchSize)))
+		}
+
 	})
 
 	fmt.Println("***************** properties *****************")
@@ -88,14 +97,21 @@ func runTransCommandFunc(cmd *cobra.Command, args []string) {
 var (
 	threadsArg int
 	targetArg  int
+	batchMode  bool
+	batchSize  uint32
 )
 
 func initClientCommand(m *cobra.Command) {
 	m.Flags().StringSliceVarP(&propertyFiles, "property_file", "P", nil, "Spefify a property file")
 	m.Flags().StringSliceVarP(&propertyValues, "prop", "p", nil, "Specify a property value with name=value")
 	m.Flags().StringVar(&tableName, "table", "", "Use the table name instead of the default \""+prop.TableNameDefault+"\"")
-	m.Flags().IntVar(&threadsArg, "threads", 1, "execute using n threads - can also be specified as the \"threadcount\" property")
-	m.Flags().IntVar(&targetArg, "target", 0, "attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
+	m.Flags().IntVar(&threadsArg, "threads", 1, "Execute using n threads - can also be specified as the \"threadcount\" property")
+	m.Flags().IntVar(&targetArg, "target", 0, "Attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
+}
+
+func loadModeCommand(m *cobra.Command) {
+	m.Flags().BoolVar(&batchMode, "batchMode", false, "Use the batch mode in workload, just the tikv support the batch mode")
+	m.Flags().Uint32Var(&batchSize, "batchSize", 16, "The size of batch in batch mode (default: 16)")
 }
 
 func newLoadCommand() *cobra.Command {
@@ -107,6 +123,7 @@ func newLoadCommand() *cobra.Command {
 	}
 
 	initClientCommand(m)
+	loadModeCommand(m)
 	return m
 }
 

--- a/db/aerospike/db.go
+++ b/db/aerospike/db.go
@@ -151,6 +151,10 @@ func (adb *aerospikedb) Insert(ctx context.Context, table string, key string, va
 	return adb.client.PutBins(nil, asKey, bins...)
 }
 
+func (adb *aerospikedb) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The aerospikedb has not implemented the batch operation")
+}
+
 // Delete deletes a record from the database.
 // table: The name of the table.
 // key: The record key of the record to delete.

--- a/db/aerospike/db.go
+++ b/db/aerospike/db.go
@@ -84,19 +84,18 @@ func (adb *aerospikedb) Scan(ctx context.Context, table string, startKey string,
 		if res.Err != nil {
 			recordset.Close()
 			return nil, res.Err
-		} else {
-			vals := make(map[string][]byte, len(res.Record.Bins))
-			for k, v := range res.Record.Bins {
-				if !filter[k] {
-					continue
-				}
-				vals[k], ok = v.([]byte)
-				if !ok {
-					return nil, errors.New("couldn't convert to byte array")
-				}
-			}
-			scanRes = append(scanRes, vals)
 		}
+		vals := make(map[string][]byte, len(res.Record.Bins))
+		for k, v := range res.Record.Bins {
+			if !filter[k] {
+				continue
+			}
+			vals[k], ok = v.([]byte)
+			if !ok {
+				return nil, errors.New("couldn't convert to byte array")
+			}
+		}
+		scanRes = append(scanRes, vals)
 		nRead++
 		if nRead == count {
 			break

--- a/db/badger/db.go
+++ b/db/badger/db.go
@@ -246,6 +246,10 @@ func (db *badgerDB) Insert(ctx context.Context, table string, key string, values
 	return err
 }
 
+func (db *badgerDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The badgerDB has not implemented the batch operation")
+}
+
 func (db *badgerDB) Delete(ctx context.Context, table string, key string) error {
 	err := db.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(db.getRowKey(table, key))

--- a/db/basic/db.go
+++ b/db/basic/db.go
@@ -210,7 +210,29 @@ func (db *basicDB) Insert(ctx context.Context, table string, key string, values 
 }
 
 func (db *basicDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
-	panic("The basicDB has not implemented the batch operation")
+	state := ctx.Value(stateKey).(*basicState)
+
+	db.delay(ctx, state)
+
+	if !db.verbose {
+		return nil
+	}
+	buf := state.buf
+	for i, key := range keys {
+		s := fmt.Sprintf("INSERT %s %s [ ", table, key)
+		buf.WriteString(s)
+		rowValue := values[i]
+		for valueKey, value := range rowValue {
+			buf.WriteString(valueKey)
+			buf.WriteByte('=')
+			buf.Write(value)
+			buf.WriteByte(' ')
+		}
+		buf.WriteByte(']')
+		fmt.Println(buf.String())
+		buf.Reset()
+	}
+	return nil
 }
 
 func (db *basicDB) Delete(ctx context.Context, table string, key string) error {

--- a/db/basic/db.go
+++ b/db/basic/db.go
@@ -209,6 +209,10 @@ func (db *basicDB) Insert(ctx context.Context, table string, key string, values 
 	return nil
 }
 
+func (db *basicDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The basicDB has not implemented the batch operation")
+}
+
 func (db *basicDB) Delete(ctx context.Context, table string, key string) error {
 	state := ctx.Value(stateKey).(*basicState)
 

--- a/db/basic/db.go
+++ b/db/basic/db.go
@@ -193,19 +193,7 @@ func (db *basicDB) Insert(ctx context.Context, table string, key string, values 
 	}
 
 	buf := state.buf
-	s := fmt.Sprintf("INSERT %s %s [ ", table, key)
-	buf.WriteString(s)
-
-	for key, value := range values {
-		buf.WriteString(key)
-		buf.WriteByte('=')
-		buf.Write(value)
-		buf.WriteByte(' ')
-	}
-
-	buf.WriteByte(']')
-	fmt.Println(buf.String())
-	buf.Reset()
+	insertRecord(buf, table, key, values)
 	return nil
 }
 
@@ -219,20 +207,23 @@ func (db *basicDB) BatchInsert(ctx context.Context, table string, keys []string,
 	}
 	buf := state.buf
 	for i, key := range keys {
-		s := fmt.Sprintf("INSERT %s %s [ ", table, key)
-		buf.WriteString(s)
-		rowValue := values[i]
-		for valueKey, value := range rowValue {
-			buf.WriteString(valueKey)
-			buf.WriteByte('=')
-			buf.Write(value)
-			buf.WriteByte(' ')
-		}
-		buf.WriteByte(']')
-		fmt.Println(buf.String())
-		buf.Reset()
+		insertRecord(buf, table, key, values[i])
 	}
 	return nil
+}
+
+func insertRecord(buf *bytes.Buffer, table string, key string, values map[string][]byte) {
+	s := fmt.Sprintf("INSERT %s %s [ ", table, key)
+	buf.WriteString(s)
+	for valueKey, value := range values {
+		buf.WriteString(valueKey)
+		buf.WriteByte('=')
+		buf.Write(value)
+		buf.WriteByte(' ')
+	}
+	buf.WriteByte(']')
+	fmt.Println(buf.String())
+	buf.Reset()
 }
 
 func (db *basicDB) Delete(ctx context.Context, table string, key string) error {

--- a/db/foundationdb/db.go
+++ b/db/foundationdb/db.go
@@ -182,6 +182,10 @@ func (db *fDB) Insert(ctx context.Context, table string, key string, values map[
 	return err
 }
 
+func (db *fDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The foundation has not implemented the batch operation")
+}
+
 func (db *fDB) Delete(ctx context.Context, table string, key string) error {
 	rowKey := db.getRowKey(table, key)
 	_, err := db.db.Transact(func(tr fdb.Transaction) (ret interface{}, e error) {

--- a/db/mysql/db.go
+++ b/db/mysql/db.go
@@ -98,7 +98,7 @@ func (c mysqlCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 func (db *mysqlDB) createTable() error {
 	tableName := db.p.GetString(prop.TableName, prop.TableNameDefault)
 
-	if db.p.GetBool(mysqlDropTable, false) && !db.p.GetBool(prop.DoTransactions, true)  {
+	if db.p.GetBool(mysqlDropTable, false) && !db.p.GetBool(prop.DoTransactions, true) {
 		if _, err := db.db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)); err != nil {
 			return err
 		}
@@ -319,6 +319,10 @@ func (db *mysqlDB) Insert(ctx context.Context, table string, key string, values 
 	buf.WriteByte(')')
 
 	return db.execQuery(ctx, buf.String(), args...)
+}
+
+func (db *mysqlDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The mysql has not implemented the batch operation")
 }
 
 func (db *mysqlDB) Delete(ctx context.Context, table string, key string) error {

--- a/db/pg/db.go
+++ b/db/pg/db.go
@@ -330,6 +330,10 @@ func (db *pgDB) Insert(ctx context.Context, table string, key string, values map
 	return db.execQuery(ctx, buf.String(), args...)
 }
 
+func (db *pgDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The postgre has not implemented the batch operation")
+}
+
 func (db *pgDB) Delete(ctx context.Context, table string, key string) error {
 	query := fmt.Sprintf(`DELETE FROM %s.%s WHERE YCSB_KEY = $1`, db.dbName, table)
 

--- a/db/rocksdb/db.go
+++ b/db/rocksdb/db.go
@@ -252,6 +252,10 @@ func (db *rocksDB) Insert(ctx context.Context, table string, key string, values 
 	return db.db.Put(db.writeOpts, rowKey, rowData)
 }
 
+func (db *rocksDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The rocksdb has not implemented the batch operation")
+}
+
 func (db *rocksDB) Delete(ctx context.Context, table string, key string) error {
 	rowKey := db.getRowKey(table, key)
 

--- a/db/tikv/coprocessor.go
+++ b/db/tikv/coprocessor.go
@@ -165,6 +165,10 @@ func (db *coprocessor) Insert(ctx context.Context, table string, key string, val
 	return tx.Commit(ctx)
 }
 
+func (db *coprocessor) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The coprocessor has not implemented the batch operation")
+}
+
 func (db *coprocessor) Delete(ctx context.Context, table string, key string) error {
 	// encode key
 	rowKey := db.table.EncodeKey(key)

--- a/db/tikv/raw.go
+++ b/db/tikv/raw.go
@@ -129,7 +129,17 @@ func (db *rawDB) Insert(ctx context.Context, table string, key string, values ma
 }
 
 func (db *rawDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
-	panic("The rawDB has not implemented the batch operation")
+	var rawKeys [][]byte
+	var rawValues [][]byte
+	for i, key := range keys {
+		rawKeys = append(rawKeys, db.getRowKey(table, key))
+		rawData, err := db.r.Encode(nil, values[i])
+		if err != nil {
+			return err
+		}
+		rawValues = append(rawValues, rawData)
+	}
+	return db.db.BatchPut(rawKeys, rawValues)
 }
 
 func (db *rawDB) Delete(ctx context.Context, table string, key string) error {

--- a/db/tikv/raw.go
+++ b/db/tikv/raw.go
@@ -128,6 +128,10 @@ func (db *rawDB) Insert(ctx context.Context, table string, key string, values ma
 	return db.db.Put(db.getRowKey(table, key), rowData)
 }
 
+func (db *rawDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The rawDB has not implemented the batch operation")
+}
+
 func (db *rawDB) Delete(ctx context.Context, table string, key string) error {
 	return db.db.Delete(db.getRowKey(table, key))
 }

--- a/db/tikv/txn.go
+++ b/db/tikv/txn.go
@@ -194,6 +194,10 @@ func (db *txnDB) Insert(ctx context.Context, table string, key string, values ma
 	return tx.Commit(ctx)
 }
 
+func (db *txnDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	panic("The txnDB has not implemented the batch operation")
+}
+
 func (db *txnDB) Delete(ctx context.Context, table string, key string) error {
 	tx, err := db.db.Begin()
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,8 +44,10 @@ func newWorker(p *properties.Properties, threadID int, threadCount int, workload
 	w := new(worker)
 	w.p = p
 	w.doTransactions = p.GetBool(prop.DoTransactions, true)
-	w.doBatch = p.GetBool(prop.DoBatch, prop.DefaultDoBatch)
 	w.batchSize = p.GetInt(prop.BatchSize, prop.DefaultBatchSize)
+	if w.batchSize > 1 {
+		w.doBatch = true
+	}
 	w.threadID = threadID
 	w.workload = workload
 	w.workDB = db
@@ -132,7 +134,7 @@ func (w *worker) run(ctx context.Context) {
 			break
 		}
 
-		w.opsDone = w.opsDone + int64(insertCount)
+		w.opsDone += int64(insertCount)
 		w.throttle(ctx, startTime)
 
 		select {

--- a/pkg/client/dbwrapper.go
+++ b/pkg/client/dbwrapper.go
@@ -66,6 +66,16 @@ func (db DbWrapper) Insert(ctx context.Context, table string, key string, values
 	return db.DB.Insert(ctx, table, key, values)
 }
 
+// BatchInsert wraps the BatchInsert method in the interface of ycsb.DB
+func (db DbWrapper) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	start := time.Now()
+	defer func() {
+		measurement.Measure("BATCH_INSERT", time.Now().Sub(start))
+	}()
+
+	return db.DB.BatchInsert(ctx, table, keys, values)
+}
+
 // Delete wraps the Delete method in the interface of ycsb.DB
 func (db DbWrapper) Delete(ctx context.Context, table string, key string) error {
 	start := time.Now()

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -34,10 +34,8 @@ const (
 	Status             = "status"
 	Label              = "label"
 	// batch mode
-	DoBatch          = "batch.mode"
-	DefaultDoBatch   = false
 	BatchSize        = "batch.size"
-	DefaultBatchSize = int(16)
+	DefaultBatchSize = int(1)
 
 	TableName         = "table"
 	TableNameDefault  = "usertable"

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -33,6 +33,11 @@ const (
 	DoTransactions     = "dotransactions"
 	Status             = "status"
 	Label              = "label"
+	// batch mode
+	DoBatch          = "bacth.mode"
+	DefaultDoBatch   = false
+	BatchSize        = "batch.size"
+	DefaultBatchSize = int(16)
 
 	TableName         = "table"
 	TableNameDefault  = "usertable"

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -34,7 +34,7 @@ const (
 	Status             = "status"
 	Label              = "label"
 	// batch mode
-	DoBatch          = "bacth.mode"
+	DoBatch          = "batch.mode"
 	DefaultDoBatch   = false
 	BatchSize        = "batch.size"
 	DefaultBatchSize = int(16)

--- a/pkg/ycsb/db.go
+++ b/pkg/ycsb/db.go
@@ -64,6 +64,12 @@ type DB interface {
 	// values: A map of field/value pairs to insert in the record.
 	Insert(ctx context.Context, table string, key string, values map[string][]byte) error
 
+	// BatchInsert inserts batch records in the database.
+	// table: The name of the table.
+	// keys: The keys of batch records.
+	// values: The values of batch records.
+	BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error
+
 	// Delete deletes a record from the database.
 	// table: The name of the table.
 	// key: The record key of the record to delete.

--- a/pkg/ycsb/workload.go
+++ b/pkg/ycsb/workload.go
@@ -40,6 +40,9 @@ type Workload interface {
 	// DoInsert does one insert operation.
 	DoInsert(ctx context.Context, db DB) error
 
+	// DoBatchInsert does batch insert and returns the number of records successfully inserted.
+	DoBatchInsert(ctx context.Context, batchSize int, db DB) (int, error)
+
 	// DoTransaction does one transaction operation.
 	DoTransaction(ctx context.Context, db DB) error
 }


### PR DESCRIPTION
In order to bench the tikv in the batch mode, I add the batch interface in the go-ycsb:

- add the `BatchInsert` function in ycsb.DB interface
- add the `DoBatchInsert` function in the ycsb.workload interface

Now the batch mode is just supported in load stage, I will support it for run stage in the next pr.