### PR TITLE
redis: simplify redis

### DIFF
--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+// CreateTLSConfig creats a TLS configuration.
+func CreateTLSConfig(caPath, certPath, keyPath string, insecureSkipVerify bool) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+		Renegotiation:      tls.RenegotiateNever,
+	}
+
+	if caPath != "" {
+		pool, err := makeCertPool([]string{caPath})
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	if certPath != "" && keyPath != "" {
+		err := loadCertificate(tlsConfig, certPath, keyPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tlsConfig, nil
+}
+
+func makeCertPool(certFiles []string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, certFile := range certFiles {
+		pem, err := ioutil.ReadFile(certFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not read certificate %q: %v", certFile, err)
+		}
+		ok := pool.AppendCertsFromPEM(pem)
+		if !ok {
+			return nil, fmt.Errorf("could not parse any PEM certificates %q: %v", certFile, err)
+		}
+	}
+	return pool, nil
+}
+
+func loadCertificate(config *tls.Config, certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("could not load keypair %s:%s: %v", certFile, keyFile, err)
+	}
+
+	config.Certificates = []tls.Certificate{cert}
+	config.BuildNameToCertificate()
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: siddontang <siddontang@gmail.com>

From #89, I use an interface to unify single and cluster to simplify the code. 

I also remove Scan support because it is not easily supported in Redis, we don't need to support it.

Another way is to introduce https://github.com/brianfrankcooper/YCSB/blob/master/redis/src/main/java/com/yahoo/ycsb/db/RedisClient.java, but I think we can just make it runnable at first. 

PTAL @JesusIslam