### PR TITLE
pkg/util: replace FNV1a with Murmur3 in hash.go

### DIFF
--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -15,14 +15,15 @@ package util
 
 import (
 	"encoding/binary"
-	"hash/fnv"
+
+	"github.com/spaolacci/murmur3"
 )
 
 // Hash64 returns a fnv Hash of the integer.
 func Hash64(n int64) int64 {
 	var b [8]byte
 	binary.BigEndian.PutUint64(b[0:8], uint64(n))
-	hash := fnv.New64a()
+	hash := murmur3.New64()
 	hash.Write(b[0:8])
 	result := int64(hash.Sum64())
 	if result < 0 {
@@ -33,14 +34,14 @@ func Hash64(n int64) int64 {
 
 // BytesHash64 returns the fnv hash of a bytes
 func BytesHash64(b []byte) int64 {
-	hash := fnv.New64a()
+	hash := murmur3.New64()
 	hash.Write(b)
 	return int64(hash.Sum64())
 }
 
 // StringHash64 returns the fnv hash of a string
 func StringHash64(s string) int64 {
-	hash := fnv.New64a()
+	hash := murmur3.New64()
 	hash.Write(Slice(s))
 	return int64(hash.Sum64())
 }


### PR DESCRIPTION
This PR tries to solve the key distribution for loading data in the default configuration.

Currently, the following code generates `YCSB_KEY` from an increasing sequence:

https://github.com/pingcap/go-ycsb/blob/d49cfa50745fd88fc700e18fb5f2e39cfa053539/pkg/workload/core.go#L255

By default(`orderedInserts = false`), the generated key is like following:

```
dbKey: user6287630695295504237 -- keyNum: 0
dbKey: user6287598809458286118 -- keyNum: 1
dbKey: user6287597709946657907 -- keyNum: 2
dbKey: user6287601008481542540 -- keyNum: 3
dbKey: user6287599908969914329 -- keyNum: 4
dbKey: user6287603207504798962 -- keyNum: 5
dbKey: user6287602107993170751 -- keyNum: 6
dbKey: user6287605406528055384 -- keyNum: 7
dbKey: user6287604307016427173 -- keyNum: 8
dbKey: user6287607605551311806 -- keyNum: 9
dbKey: user6287606506039683595 -- keyNum: 10
dbKey: user6287609804574568228 -- keyNum: 11
dbKey: user6287608705062940017 -- keyNum: 12
dbKey: user6287610904086196439 -- keyNum: 13
dbKey: user6287612003597824650 -- keyNum: 14
dbKey: user6287614202621081072 -- keyNum: 15
dbKey: user6287581217272234742 -- keyNum: 16
dbKey: user6287580117760606531 -- keyNum: 17
dbKey: user6287613103109452861 -- keyNum: 18
dbKey: user6287583416295491164 -- keyNum: 19
dbKey: user6287582316783862953 -- keyNum: 20
...
```
Notice the similarity for the keys generated, for `YCSB_KEY`, this leads to a high correlation locally but low correlation globally:

```
(load 1 million rows)
MySQL [test]> select correlation from mysql.stats_histograms where table_id=44 order by hist_id limit 1;
+-------------+
| correlation |
+-------------+
|      0.5873 |
+-------------+
1 row in set (0.01 sec)

(load 10 million rows)
MySQL [test]> select correlation from mysql.stats_histograms where table_id=44 order by hist_id limit 1;
+-------------+
| correlation |
+-------------+
|      0.0031 |
+-------------+
1 row in set (0.01 sec)
```
The different correlation misleads database SQL planner to make bad choice between data/index scans.

Compared with `FNV1a`, `murmur3` gives much better output randomness for increasing sequence number:
```
Input: 0, MurmurHash64: 2945182322382062539, Fnv64: 6284781860667377211
Input: 1, MurmurHash64: 6292367497774912474, Fnv64: 6284782960179005422
Input: 2, MurmurHash64: 8218881827949364593, Fnv64: 6284784059690633633
Input: 3, MurmurHash64: 8048510690352527683, Fnv64: 6284785159202261844
Input: 4, MurmurHash64: 1830508272351686621, Fnv64: 6284786258713890055
Input: 5, MurmurHash64: 4464361019114304900, Fnv64: 6284787358225518266
Input: 6, MurmurHash64: 6268297055439790106, Fnv64: 6284788457737146477
Input: 7, MurmurHash64: 5038316157564330072, Fnv64: 6284789557248774688
Input: 8, MurmurHash64: 3989579132296173906, Fnv64: 6284773064574351523
Input: 9, MurmurHash64: 2638303903097405552, Fnv64: 6284774164085979734
Input: 10, MurmurHash64: 1944024169073138009, Fnv64: 6284775263597607945
Input: 11, MurmurHash64: 3109524872961303651, Fnv64: 6284776363109236156
Input: 12, MurmurHash64: 6030257681769843457, Fnv64: 6284777462620864367
Input: 13, MurmurHash64: 5222276830576067764, Fnv64: 6284778562132492578
Input: 14, MurmurHash64: 3421398847698307239, Fnv64: 6284779661644120789
Input: 15, MurmurHash64: 3520484983264228142, Fnv64: 6284780761155749000
Input: 16, MurmurHash64: 6388174459908673966, Fnv64: 6284764268481325835
Input: 17, MurmurHash64: 8660407606519473992, Fnv64: 6284765367992954046
Input: 18, MurmurHash64: 7599759837043657056, Fnv64: 6284766467504582257
Input: 19, MurmurHash64: 8829757208421597067, Fnv64: 6284767567016210468
Input: 20, MurmurHash64: 5897291465803793390, Fnv64: 6284768666527838679
```
After replacement, the correlation of `YCSB_KEY` will always low no matter how many rows are inserted.

Related reports can also be found in [this artical](https://research.neustar.biz/2012/02/02/choosing-a-good-hash-function-part-3/), in which:
```
Basically, if we keep all of the input bits the same, save for exactly 1 which we flip, we’d hope that each of our hash function’s output bits changes with probability 1/2.
...
...
This test absolutely wrecks AP, SDBM, both FNV twins, and RS
```

