### PR TITLE
bugfix: default threadcount 100 => 1

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -167,7 +167,7 @@ func NewClient(p *properties.Properties, workload ycsb.Workload, db ycsb.DB) *Cl
 // Run runs the workload to the target DB, and blocks until all workers end.
 func (c *Client) Run(ctx context.Context) {
 	var wg sync.WaitGroup
-	threadCount := c.p.GetInt(prop.ThreadCount, 100)
+	threadCount := c.p.GetInt(prop.ThreadCount, 1)
 
 	wg.Add(threadCount)
 	measureCtx, measureCancel := context.WithCancel(ctx)


### PR DESCRIPTION
Usage says default ”threadcount" is 1, but 100 indeed.

```
--threads int             Execute using n threads - can also be specified as the "threadcount" property (default 1)

```