### PR TITLE
db: fix a bug of 'firstField'

### DIFF
--- a/db/cassandra/db.go
+++ b/db/cassandra/db.go
@@ -195,7 +195,9 @@ func (db *cassandraDB) Update(ctx context.Context, table string, key string, val
 	pairs := util.NewFieldPairs(values)
 	args := make([]interface{}, 0, len(values)+1)
 	for _, p := range pairs {
-		if !firstField {
+		if firstField {
+			firstField = false
+		} else {
 			buf.WriteString(", ")
 		}
 

--- a/db/mysql/db.go
+++ b/db/mysql/db.go
@@ -300,7 +300,9 @@ func (db *mysqlDB) Update(ctx context.Context, table string, key string, values 
 	pairs := util.NewFieldPairs(values)
 	args := make([]interface{}, 0, len(values)+1)
 	for _, p := range pairs {
-		if !firstField {
+		if firstField {
+			firstField = false
+		} else {
 			buf.WriteString(", ")
 		}
 

--- a/db/pg/db.go
+++ b/db/pg/db.go
@@ -302,7 +302,9 @@ func (db *pgDB) Update(ctx context.Context, table string, key string, values map
 	placeHolderIndex := 1
 	pairs := util.NewFieldPairs(values)
 	for _, p := range pairs {
-		if !firstField {
+		if firstField {
+			firstField = false
+		} else {
 			buf.WriteString(", ")
 		}
 

--- a/db/sqlite/db.go
+++ b/db/sqlite/db.go
@@ -226,7 +226,9 @@ func (db *sqliteDB) Update(ctx context.Context, table string, key string, values
 	pairs := util.NewFieldPairs(values)
 	args := make([]interface{}, 0, len(values)+1)
 	for _, p := range pairs {
-		if !firstField {
+		if firstField {
+			firstField = false
+		} else {
 			buf.WriteString(", ")
 		}
 


### PR DESCRIPTION
This PR fixes a tiny bug caused by not updating `firstField`.

This bug causes a wrong SQL when `writeallfields` is set to `true`