### PR TITLE
db: fix a bug caused by sorting the same slice concurrently

### DIFF
--- a/db/mysql/db.go
+++ b/db/mysql/db.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/pingcap/go-ycsb/pkg/prop"
@@ -243,10 +242,7 @@ func (db *mysqlDB) Read(ctx context.Context, table string, key string, fields []
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s %s WHERE YCSB_KEY = ?`, table, db.forceIndexKeyword)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY = ?`, strings.Join(sorted, ","), table, db.forceIndexKeyword)
+		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY = ?`, strings.Join(fields, ","), table, db.forceIndexKeyword)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -266,10 +262,7 @@ func (db *mysqlDB) Scan(ctx context.Context, table string, startKey string, coun
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, table, db.forceIndexKeyword)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(sorted, ","), table, db.forceIndexKeyword)
+		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(fields, ","), table, db.forceIndexKeyword)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)

--- a/db/mysql/db.go
+++ b/db/mysql/db.go
@@ -243,8 +243,10 @@ func (db *mysqlDB) Read(ctx context.Context, table string, key string, fields []
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s %s WHERE YCSB_KEY = ?`, table, db.forceIndexKeyword)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY = ?`, strings.Join(fields, ","), table, db.forceIndexKeyword)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY = ?`, strings.Join(sorted, ","), table, db.forceIndexKeyword)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -264,8 +266,10 @@ func (db *mysqlDB) Scan(ctx context.Context, table string, startKey string, coun
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, table, db.forceIndexKeyword)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(fields, ","), table, db.forceIndexKeyword)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(sorted, ","), table, db.forceIndexKeyword)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)

--- a/db/pg/db.go
+++ b/db/pg/db.go
@@ -244,8 +244,10 @@ func (db *pgDB) Read(ctx context.Context, table string, key string, fields []str
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = $1`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = $1`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = $1`, strings.Join(sorted, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -265,8 +267,10 @@ func (db *pgDB) Scan(ctx context.Context, table string, startKey string, count i
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, strings.Join(sorted, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)

--- a/db/pg/db.go
+++ b/db/pg/db.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/pingcap/go-ycsb/pkg/prop"
@@ -244,10 +243,7 @@ func (db *pgDB) Read(ctx context.Context, table string, key string, fields []str
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = $1`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = $1`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = $1`, strings.Join(fields, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -267,10 +263,7 @@ func (db *pgDB) Scan(ctx context.Context, table string, startKey string, count i
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= $1 LIMIT $2`, strings.Join(fields, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)

--- a/db/spanner/db.go
+++ b/db/spanner/db.go
@@ -286,8 +286,10 @@ func (db *spannerDB) Read(ctx context.Context, table string, key string, fields 
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = @key`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = @key`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = @key`, strings.Join(sorted, ","), table)
 	}
 
 	stmt := spanner.NewStatement(query)
@@ -309,8 +311,10 @@ func (db *spannerDB) Scan(ctx context.Context, table string, startKey string, co
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, strings.Join(sorted, ","), table)
 	}
 
 	stmt := spanner.NewStatement(query)

--- a/db/spanner/db.go
+++ b/db/spanner/db.go
@@ -21,7 +21,6 @@ import (
 	"os/user"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 
 	"cloud.google.com/go/spanner"
@@ -286,10 +285,7 @@ func (db *spannerDB) Read(ctx context.Context, table string, key string, fields 
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = @key`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = @key`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = @key`, strings.Join(fields, ","), table)
 	}
 
 	stmt := spanner.NewStatement(query)
@@ -311,10 +307,7 @@ func (db *spannerDB) Scan(ctx context.Context, table string, startKey string, co
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= @key LIMIT @limit`, strings.Join(fields, ","), table)
 	}
 
 	stmt := spanner.NewStatement(query)

--- a/db/sqlite/db.go
+++ b/db/sqlite/db.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/pingcap/go-ycsb/pkg/prop"
@@ -173,10 +172,7 @@ func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields [
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = ?`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = ?`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = ?`, strings.Join(fields, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -195,10 +191,7 @@ func (db *sqliteDB) Scan(ctx context.Context, table string, startKey string, cou
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, table)
 	} else {
-		sorted := make([]string, len(fields))
-		copy(sorted, fields)
-		sort.Strings(sorted)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(sorted, ","), table)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(fields, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)

--- a/db/sqlite/db.go
+++ b/db/sqlite/db.go
@@ -173,8 +173,10 @@ func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields [
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = ?`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = ?`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = ?`, strings.Join(sorted, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, 1, key)
@@ -193,8 +195,10 @@ func (db *sqliteDB) Scan(ctx context.Context, table string, startKey string, cou
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, table)
 	} else {
-		sort.Strings(fields)
-		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(fields, ","), table)
+		sorted := make([]string, len(fields))
+		copy(sorted, fields)
+		sort.Strings(sorted)
+		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(sorted, ","), table)
 	}
 
 	rows, err := db.queryRows(ctx, query, count, startKey, count)


### PR DESCRIPTION
This PR tries to fix a data race bug caused by calling `sort.Strings(fields)` in multiple goroutines