### PR TITLE
add "keyprefix" property and command argument 

### DIFF
--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -42,6 +42,10 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		if cmd.Flags().Changed("target") {
 			globalProps.Set(prop.Target, strconv.Itoa(targetArg))
 		}
+
+		if cmd.Flags().Changed("keyprefix") {
+			globalProps.Set(prop.KeyPrefix, keyprefixArg)
+		}
 	})
 
 	fmt.Println("***************** properties *****************")
@@ -67,8 +71,9 @@ func runTransCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 var (
-	threadsArg int
-	targetArg  int
+	threadsArg   int
+	targetArg    int
+	keyprefixArg string
 )
 
 func initClientCommand(m *cobra.Command) {
@@ -77,6 +82,7 @@ func initClientCommand(m *cobra.Command) {
 	m.Flags().StringVar(&tableName, "table", "", "Use the table name instead of the default \""+prop.TableNameDefault+"\"")
 	m.Flags().IntVar(&threadsArg, "threads", 1, "Execute using n threads - can also be specified as the \"threadcount\" property")
 	m.Flags().IntVar(&targetArg, "target", 0, "Attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
+	m.Flags().StringVar(&keyprefixArg, "keyprefix", prop.KeyPrefixDefault, "Specify the prefix of YCSB_KEY - can also be specified as the \"keyprefix\" property")
 }
 
 func newLoadCommand() *cobra.Command {

--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -42,10 +42,6 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		if cmd.Flags().Changed("target") {
 			globalProps.Set(prop.Target, strconv.Itoa(targetArg))
 		}
-
-		if cmd.Flags().Changed("keyprefix") {
-			globalProps.Set(prop.KeyPrefix, keyprefixArg)
-		}
 	})
 
 	fmt.Println("***************** properties *****************")
@@ -71,9 +67,8 @@ func runTransCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 var (
-	threadsArg   int
-	targetArg    int
-	keyprefixArg string
+	threadsArg int
+	targetArg  int
 )
 
 func initClientCommand(m *cobra.Command) {
@@ -82,7 +77,6 @@ func initClientCommand(m *cobra.Command) {
 	m.Flags().StringVar(&tableName, "table", "", "Use the table name instead of the default \""+prop.TableNameDefault+"\"")
 	m.Flags().IntVar(&threadsArg, "threads", 1, "Execute using n threads - can also be specified as the \"threadcount\" property")
 	m.Flags().IntVar(&targetArg, "target", 0, "Attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
-	m.Flags().StringVar(&keyprefixArg, "keyprefix", prop.KeyPrefixDefault, "Specify the prefix of YCSB_KEY - can also be specified as the \"keyprefix\" property")
 }
 
 func newLoadCommand() *cobra.Command {

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -103,4 +103,7 @@ const (
 
 	Silence        = "silence"
 	SilenceDefault = true
+
+	KeyPrefix        = "keyprefix"
+	KeyPrefixDefault = "user"
 )

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -155,7 +155,8 @@ func (c *core) buildKeyName(keyNum int64) string {
 		keyNum = util.Hash64(keyNum)
 	}
 
-	return fmt.Sprintf("user%0[2]*[1]d", keyNum, c.zeroPadding)
+	prefix := c.p.GetString(prop.KeyPrefix, prop.KeyPrefixDefault)
+	return fmt.Sprintf("%s%0[3]*[2]d", prefix, keyNum, c.zeroPadding)
 }
 
 func (c *core) buildSingleValue(state *coreState, key string) map[string][]byte {


### PR DESCRIPTION
Support to customize the prefix of YCSB_KEY.

Refer to #121 
> YCSB_KEY is the format of "userXXXXXXXX" and the prefix is "user".
In my benchmark, a key with 40 bytes or longer is needed.
So I suggest a property of custom prefix.