### PR TITLE
pkg/workload/core: move fields related to read/update to coreState

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -140,7 +140,7 @@ func (c *core) InitThread(ctx context.Context, _ int, _ int) context.Context {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	var readFields []string
 	if c.readAllFields {
-		readFields = make([]string, 0, len(c.fieldNames))
+		readFields = make([]string, len(c.fieldNames))
 		copy(readFields, c.fieldNames)
 	} else {
 		readFields = []string{c.fieldNames[c.fieldChooser.Next(r)]}
@@ -149,12 +149,13 @@ func (c *core) InitThread(ctx context.Context, _ int, _ int) context.Context {
 
 	var writeFields []string
 	if c.writeAllFields {
-		writeFields = make([]string, 0, len(c.fieldNames))
+		writeFields = make([]string, len(c.fieldNames))
 		copy(writeFields, c.fieldNames)
 	} else {
 		writeFields = []string{c.fieldNames[c.fieldChooser.Next(r)]}
 	}
 	sort.Strings(writeFields)
+	fmt.Printf(" WWWWWWrite fieldnames: %v\n", writeFields)
 
 	state := &coreState{
 		r:           r,

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -155,7 +155,6 @@ func (c *core) InitThread(ctx context.Context, _ int, _ int) context.Context {
 		writeFields = []string{c.fieldNames[c.fieldChooser.Next(r)]}
 	}
 	sort.Strings(writeFields)
-	fmt.Printf(" WWWWWWrite fieldnames: %v\n", writeFields)
 
 	state := &coreState{
 		r:           r,


### PR DESCRIPTION
This PR does some refactors in `pkg/workload/core`:

* Moves `fields` used in Reads/Scans to `coreState.readFields`
* Moves `fields` used in Updates to `coreState.writeFields`

Now `coreState.readFields` and `coreState.writeFields` are picked from `fieldNames` and sorted in `InitThread` and it is per-goroutine resources.

This PR also removes `buildSingleValue`, adds `buildAllValues`(used for Inserts) and `buildUpdateValues`(used for Updates) instead.
