### PR TITLE
Fix the dataintegrity_check bug

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -37,7 +37,7 @@ type contextKey string
 const stateKey = contextKey("core")
 
 type coreState struct {
-	r          *rand.Rand
+	r *rand.Rand
 	// fieldNames is a copy of core.fieldNames to be goroutine-local
 	fieldNames []string
 }
@@ -229,7 +229,7 @@ func (c *core) buildDeterministicValue(state *coreState, key string, fieldKey st
 	b := bytes.NewBuffer(buf[0:0])
 	b.WriteString(key)
 	b.WriteByte(':')
-	b.WriteString(fieldKey)
+	b.WriteString(strings.ToLower(fieldKey))
 	for int64(b.Len()) < size {
 		b.WriteByte(':')
 		n := util.BytesHash64(b.Bytes())


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

fix https://github.com/pingcap/tidb/issues/14325

When inserting data, the fieldKey was all in lower case, so the data generated by `buildDeterministicValue` was in the format of `user6282608126178782514:field6:xxx`. 

But when use `buildDeterministicValue` to generate expect value again, fieldKey that being generated according to column names queried from `usertable` is in upper case, so expected value generated is in the format of `user6282608126178782514:FIELD6:xxx`

```
mysql> desc usertable;
+----------+--------------+------+------+---------+-------+
| Field    | Type         | Null | Key  | Default | Extra |
+----------+--------------+------+------+---------+-------+
| YCSB_KEY | varchar(64)  | NO   | PRI  | NULL    |       |
| FIELD0   | varchar(100) | YES  |      | NULL    |       |
| FIELD1   | varchar(100) | YES  |      | NULL    |       |
| FIELD2   | varchar(100) | YES  |      | NULL    |       |
| FIELD3   | varchar(100) | YES  |      | NULL    |       |
| FIELD4   | varchar(100) | YES  |      | NULL    |       |
| FIELD5   | varchar(100) | YES  |      | NULL    |       |
| FIELD6   | varchar(100) | YES  |      | NULL    |       |
| FIELD7   | varchar(100) | YES  |      | NULL    |       |
| FIELD8   | varchar(100) | YES  |      | NULL    |       |
| FIELD9   | varchar(100) | YES  |      | NULL    |       |
+----------+--------------+------+------+---------+-------+
```