### PR TITLE
Controlling latency makes data normally distributed in the time dimension

### DIFF
--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -52,7 +52,7 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 
 	c := client.NewClient(globalProps, globalWorkload, globalDB)
 	start := time.Now()
-	c.Run(globalContext)
+	c.Run(globalContext,start)
 
 	fmt.Printf("Run finished, takes %s\n", time.Now().Sub(start))
 	measurement.Output()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"math"
 	"os"
 
 	//"os"
 	"sync"
 	"time"
-	"math"
 
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/measurement"
@@ -66,18 +66,16 @@ func newWorker(p *properties.Properties, threadID int, threadCount int, workload
 			totalOpCount = p.GetInt64(prop.RecordCount, 0)
 		}
 	}
-	//Keep data running
-	if !p.GetBool(prop.NormalDataInTime, prop.NormalDataInTimeDefault) {
-		if totalOpCount < int64(threadCount) {
-			fmt.Printf("totalOpCount(%s/%s/%s): %d should be bigger than threadCount: %d",
-				prop.OperationCount,
-				prop.InsertCount,
-				prop.RecordCount,
-				totalOpCount,
-				threadCount)
 
-			os.Exit(-1)
-		}
+	if totalOpCount < int64(threadCount) {
+		fmt.Printf("totalOpCount(%s/%s/%s): %d should be bigger than threadCount: %d",
+			prop.OperationCount,
+			prop.InsertCount,
+			prop.RecordCount,
+			totalOpCount,
+			threadCount)
+
+		os.Exit(-1)
 	}
 
 	w.opCount = totalOpCount / int64(threadCount)

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -107,12 +107,15 @@ const (
 	KeyPrefix        = "keyprefix"
 	KeyPrefixDefault = "user"
 
+	NormalDataInTime       = "normal_data_in_time"
+	NormalDataInTimeDefault = false
 	ExpectedValue = "expectedvalue"
-	ExpectedValueDefault = float64(30)
+	ExpectedValueDefault = float64(10)
 	StandardDeviation = "standarddeviation"
-	StandardDeviationDefault = float64(10)
+	StandardDeviationDefault = float64(2)
 	TimeDelay = "timedelay"
 	TimeDelayDefault = float64(100000)
 	TimePeriod = "timeperiod"
 	TimePeriodDefault = int(20)
+
 )

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -106,4 +106,13 @@ const (
 
 	KeyPrefix        = "keyprefix"
 	KeyPrefixDefault = "user"
+
+	ExpectedValue = "expectedvalue"
+	ExpectedValueDefault = float64(30)
+	StandardDeviation = "standarddeviation"
+	StandardDeviationDefault = float64(10)
+	TimeDelay = "timedelay"
+	TimeDelayDefault = float64(100000)
+	TimePeriod = "timeperiod"
+	TimePeriodDefault = int(20)
 )

--- a/workloads/workload_normal
+++ b/workloads/workload_normal
@@ -205,7 +205,8 @@ timeseries.granularity=1000
 # htrace.htraced.receiver.address=example.com:9075
 # htrace.htraced.error.log.period.ms=10000
 
-
+# NormalDataInTime = "normal_data_in_time"
+# NormalDataInTimeDefault = false
 # ExpectedValue = "expectedvalue"
 # ExpectedValueDefault = float64(10)
 # StandardDeviation = "standarddeviation"
@@ -215,7 +216,8 @@ timeseries.granularity=1000
 # TimePeriod = "timeperiod"
 # TimePeriodDefault = int(20)
 
-expectedvalue = 20
+normal_data_in_time = true
+expectedvalue = 10
 standarddeviation = 3
 timedelay = 10000
-timeperiod = 40
+timeperiod = 20

--- a/workloads/workload_normal
+++ b/workloads/workload_normal
@@ -1,0 +1,221 @@
+# Copyright (c) 2012-2016 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+
+# Yahoo! Cloud System Benchmark
+# Workload Template: Default Values
+#
+# File contains all properties that can be set to define a
+# YCSB session. All properties are set to their default
+# value if one exists. If not, the property is commented
+# out. When a property has a finite number of settings,
+# the default is enabled and the alternates are shown in
+# comments below it.
+# 
+# Use of most explained through comments in Client.java or 
+# CoreWorkload.java or on the YCSB wiki page:
+# https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties
+
+# The name of the workload class to use
+workload=core
+
+# There is no default setting for recordcount but it is
+# required to be set.
+# The number of records in the table to be inserted in
+# the load phase or the number of records already in the 
+# table before the run phase.
+recordcount=50000000
+
+# There is no default setting for operationcount but it is
+# required to be set.
+# The number of operations to use during the run phase.
+operationcount=0
+
+# The number of thread.
+threadcount=200
+
+# The number of insertions to do, if different from recordcount.
+# Used with insertstart to grow an existing table.
+#insertcount=
+
+# The offset of the first insertion
+insertstart=0
+
+# The number of fields in a record
+fieldcount=10
+
+# The size of each field (in bytes)
+fieldlength=100
+
+# Should read all fields
+readallfields=true
+
+# Should write all fields on update
+writeallfields=false
+
+# The distribution used to choose the length of a field
+#fieldlengthdistribution=constant
+#fieldlengthdistribution=uniform
+#fieldlengthdistribution=zipfian
+
+# What proportion of operations are reads
+readproportion=1
+
+# What proportion of operations are updates
+updateproportion=0
+
+# What proportion of operations are inserts
+insertproportion=0
+
+# What proportion of operations read then modify a record
+readmodifywriteproportion=0
+
+# What proportion of operations are scans
+scanproportion=0
+
+# On a single scan, the maximum number of records to access
+maxscanlength=1000
+
+# The distribution used to choose the number of records to access on a scan
+scanlengthdistribution=uniform
+#scanlengthdistribution=zipfian
+
+# Should records be inserted in order or pseudo-randomly
+insertorder=hashed
+#insertorder=ordered
+
+# The distribution of requests across the keyspace
+requestdistribution=zipfian
+#requestdistribution=uniform
+#requestdistribution=latest
+
+# Percentage of data items that constitute the hot set
+hotspotdatafraction=0.2
+
+# Percentage of operations that access the hot set
+hotspotopnfraction=0.8
+
+# Maximum execution time in seconds
+#maxexecutiontime= 
+
+# The name of the database table to run queries against
+table=table1
+
+# The column family of fields (required by some databases)
+#columnfamily=
+
+# How the latency measurements are presented
+measurementtype=histogram
+#measurementtype=timeseries
+#measurementtype=raw
+# When measurementtype is set to raw, measurements will be output
+# as RAW datapoints in the following csv format:
+# "operation, timestamp of the measurement, latency in us"
+#
+# Raw datapoints are collected in-memory while the test is running. Each
+# data point consumes about 50 bytes (including java object overhead).
+# For a typical run of 1 million to 10 million operations, this should
+# fit into memory most of the time. If you plan to do 100s of millions of
+# operations per run, consider provisioning a machine with larger RAM when using
+# the RAW measurement type, or split the run into multiple runs.
+#
+# Optionally, you can specify an output file to save raw datapoints.
+# Otherwise, raw datapoints will be written to stdout.
+# The output file will be appended to if it already exists, otherwise
+# a new output file will be created.
+#measurement.raw.output_file = /tmp/your_output_file_for_this_run
+
+# JVM Reporting.
+#
+# Measure JVM information over time including GC counts, max and min memory
+# used, max and min thread counts, max and min system load and others. This
+# setting must be enabled in conjunction with the "-s" flag to run the status
+# thread. Every "status.interval", the status thread will capture JVM 
+# statistics and record the results. At the end of the run, max and mins will
+# be recorded.
+# measurement.trackjvm = false
+
+# The range of latencies to track in the histogram (milliseconds)
+histogram.buckets=1000
+
+# Granularity for time series (in milliseconds)
+timeseries.granularity=1000
+
+# Latency reporting.
+#
+# YCSB records latency of failed operations separately from successful ones.
+# Latency of all OK operations will be reported under their operation name,
+# such as [READ], [UPDATE], etc.
+#
+# For failed operations:
+# By default we don't track latency numbers of specific error status.
+# We just report latency of all failed operation under one measurement name
+# such as [READ-FAILED]. But optionally, user can configure to have either:
+# 1. Record and report latency for each and every error status code by
+#    setting reportLatencyForEachError to true, or
+# 2. Record and report latency for a select set of error status codes by
+#    providing a CSV list of Status codes via the "latencytrackederrors"
+#    property.
+# reportlatencyforeacherror=false
+# latencytrackederrors="<comma separated strings of error codes>"
+
+# Insertion error retry for the core workload.
+#
+# By default, the YCSB core workload does not retry any operations.
+# However, during the load process, if any insertion fails, the entire
+# load process is terminated.
+# If a user desires to have more robust behavior during this phase, they can
+# enable retry for insertion by setting the following property to a positive
+# number.
+# core_workload_insertion_retry_limit = 0
+#
+# the following number controls the interval between retries (in seconds):
+# core_workload_insertion_retry_interval = 3
+
+# Distributed Tracing via Apache HTrace (http://htrace.incubator.apache.org/)
+#
+# Defaults to blank / no tracing
+# Below sends to a local file, sampling at 0.1%
+#
+# htrace.sampler.classes=ProbabilitySampler
+# htrace.sampler.fraction=0.001
+# htrace.span.receiver.classes=org.apache.htrace.core.LocalFileSpanReceiver
+# htrace.local.file.span.receiver.path=/some/path/to/local/file
+#
+# To capture all spans, use the AlwaysSampler
+#
+# htrace.sampler.classes=AlwaysSampler
+#
+# To send spans to an HTraced receiver, use the below and ensure
+# your classpath contains the htrace-htraced jar (i.e. when invoking the ycsb
+# command add -cp /path/to/htrace-htraced.jar)
+#
+# htrace.span.receiver.classes=org.apache.htrace.impl.HTracedSpanReceiver
+# htrace.htraced.receiver.address=example.com:9075
+# htrace.htraced.error.log.period.ms=10000
+
+
+# ExpectedValue = "expectedvalue"
+# ExpectedValueDefault = float64(10)
+# StandardDeviation = "standarddeviation"
+# StandardDeviationDefault = float64(2)
+# TimeDelay = "timedelay"
+# TimeDelayDefault = float64(100000)	
+# TimePeriod = "timeperiod"
+# TimePeriodDefault = int(20)
+
+expectedvalue = 20
+standarddeviation = 3
+timedelay = 10000
+timeperiod = 40


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Add a function to keep the load running, which is a periodic normal distribution in the time dimension

### What is changed and how it works?
Add new parameters in prop.go.
normal_data_in_time : 
Control this function, the default value is false,which means to ignore this function. If the value is true, the go-ycsb will not stop and you need to kill process if you want to stop it.
expectedvalue :
Mean of normal distribution.
standarddeviation :
Standard deviation of normal distribution.
timedelay = 10000 :
Qps decreases with increasing latency.
timeperiod = 20 :
One cycle duration.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 
Use this workload file - workload_normal.
QPS and TIKV CPU USAGE are as follows：
![image](https://user-images.githubusercontent.com/46194778/80216694-074af200-8671-11ea-94fa-ee359ca888cd.png)

![image](https://user-images.githubusercontent.com/46194778/80216706-0c0fa600-8671-11ea-8be1-ae272015e20c.png)

