### PR TITLE
Mongo/add tls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-ycsb 
+# go-ycsb
 
 go-ycsb is a Go port of [YCSB](https://github.com/brianfrankcooper/YCSB). It fully supports all YCSB generators and the Core workload so we can do the basic CRUD benchmarks with Go.
 
@@ -22,7 +22,7 @@ Notice:
 + To use FoundationDB, you must install [client](https://www.foundationdb.org/download/) library at first, now the supported version is 6.2.11.
 + To use RocksDB, you must follow [INSTALL](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) to install RocksDB at first.
 
-## Usage 
+## Usage
 
 Mostly, we can start from the offical document [Running-a-Workload](https://github.com/brianfrankcooper/YCSB/wiki/Running-a-Workload).
 
@@ -62,7 +62,7 @@ Available Commands:
 
 - MySQL / TiDB
 - TiKV
-- FoundationDB 
+- FoundationDB
 - Aerospike
 - Badger
 - Cassandra / ScyllaDB
@@ -193,7 +193,7 @@ Common configurations:
 |rocksdb.index_type|kBinarySearch|Sets the index type used for this table. __kBinarySearch__: A space efficient index block that is optimized for binary-search-based index. __kHashSearch__: The hash index, if enabled, will do the hash lookup when `Options.prefix_extractor` is provided. __kTwoLevelIndexSearch__: A two-level index implementation. Both levels are binary search indexes|
 |rocksdb.block_align|false|Enable/Disable align data blocks on lesser of page size and block size|
 
-### Spanner 
+### Spanner
 
 |field|default value|description|
 |-|-|-|
@@ -209,7 +209,7 @@ Common configurations:
 |sqlite.journalmode|"DELETE"|Journal mode: DELETE, TRUNCSTE, PERSIST, MEMORY, WAL, OFF|
 |sqlite.cache|"Shared"|Cache: shared, private|
 
-### Cassandra 
+### Cassandra
 
 |field|default value|description|
 |-|-|-|
@@ -222,6 +222,8 @@ Common configurations:
 |field|default value|description|
 |-|-|-|
 |mongodb.uri|"mongodb://127.0.0.1:27017"|MongoDB URI|
+|mongodb.tls_skip_verify|false|Enable/disable server ca certificate verification|
+|mongodb.tls_ca_file|""|Path to mongodb server ca certificate file|
 |mongodb.namespace|"ycsb.ycsb"|Namespace to use|
 |mongodb.authdb|"admin"|Authentication database|
 |mongodb.username|N/A|Username for authentication|

--- a/cmd/go-ycsb/main.go
+++ b/cmd/go-ycsb/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -91,6 +92,9 @@ func initialGlobal(dbName string, onProperties func()) {
 
 	for _, prop := range propertyValues {
 		seps := strings.SplitN(prop, "=", 2)
+		if len(seps) != 2 {
+			log.Fatalf("bad property: `%s`, expected format `name=value`", prop)
+		}
 		globalProps.Set(seps[0], seps[1])
 	}
 

--- a/db/mongodb/db.go
+++ b/db/mongodb/db.go
@@ -2,8 +2,12 @@ package mongodb
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
 
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
@@ -15,11 +19,13 @@ import (
 )
 
 const (
-	mongodbUri       = "mongodb.uri"
-	mongodbNamespace = "mongodb.namespace"
-	mongodbAuthdb    = "mongodb.authdb"
-	mongodbUsername  = "mongodb.username"
-	mongodbPassword  = "mongodb.password"
+	mongodbUri           = "mongodb.uri"
+	mongodbTLSSkipVerify = "mongodb.tls_skip_verify"
+	mongodbTLSCAFile     = "mongodb.tls_ca_file"
+	mongodbNamespace     = "mongodb.namespace"
+	mongodbAuthdb        = "mongodb.authdb"
+	mongodbUsername      = "mongodb.username"
+	mongodbPassword      = "mongodb.password"
 
 	mongodbUriDefault       = "mongodb://127.0.0.1:27017"
 	mongodbNamespaceDefault = "ycsb.ycsb"
@@ -126,8 +132,11 @@ func (c mongodbCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 	uri := p.GetString(mongodbUri, mongodbUriDefault)
 	nss := p.GetString(mongodbNamespace, mongodbNamespaceDefault)
 	authdb := p.GetString(mongodbAuthdb, mongodbAuthdbDefault)
+	tlsSkipVerify := p.GetBool(mongodbTLSSkipVerify, false)
+	caFile := p.GetString(mongodbTLSCAFile, "")
 
-	if _, err := connstring.Parse(uri); err != nil {
+	connString, err := connstring.Parse(uri)
+	if err != nil {
 		return nil, err
 	}
 	ns := command.ParseNamespace(nss)
@@ -139,6 +148,27 @@ func (c mongodbCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 	defer cancel()
 
 	cliOpts := options.Client().ApplyURI(uri)
+	if len(connString.Hosts) > 0 {
+		servername := strings.Split(connString.Hosts[0], ":")[0]
+		log.Printf("using server name for tls: %s\n", servername)
+		cliOpts.TLSConfig.ServerName = servername
+	}
+	if tlsSkipVerify {
+		log.Println("skipping tls cert validation")
+		cliOpts.TLSConfig.InsecureSkipVerify = true
+	}
+
+	if caFile != "" {
+		// Load CA cert
+		caCert, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		cliOpts.TLSConfig.RootCAs = caCertPool
+	}
 
 	username, usrExist := p.Get(mongodbUsername)
 	password, pwdExist := p.Get(mongodbPassword)


### PR DESCRIPTION
This adds tls support for the mongodb database. This is useful if the mongodb server forces tls connections.

The user can now:
-  specify the servers ca certifacte file or
-  skip tls certificate validation. 

Bugfixes:
It fixes a small bug in the properties initialization step. Malformed properties (not of the form: "key=value") caused
a nil panic.