### PR TITLE
cmd: support to indicate report interval by arguments

### DIFF
--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -42,6 +42,10 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		if cmd.Flags().Changed("target") {
 			globalProps.Set(prop.Target, strconv.Itoa(targetArg))
 		}
+
+		if cmd.Flags().Changed("interval") {
+			globalProps.Set(prop.LogInterval, strconv.Itoa(reportInterval))
+		}
 	})
 
 	fmt.Println("***************** properties *****************")
@@ -67,8 +71,9 @@ func runTransCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 var (
-	threadsArg int
-	targetArg  int
+	threadsArg     int
+	targetArg      int
+	reportInterval int
 )
 
 func initClientCommand(m *cobra.Command) {
@@ -77,6 +82,7 @@ func initClientCommand(m *cobra.Command) {
 	m.Flags().StringVar(&tableName, "table", "", "Use the table name instead of the default \""+prop.TableNameDefault+"\"")
 	m.Flags().IntVar(&threadsArg, "threads", 1, "Execute using n threads - can also be specified as the \"threadcount\" property")
 	m.Flags().IntVar(&targetArg, "target", 0, "Attempt to do n operations per second (default: unlimited) - can also be specified as the \"target\" property")
+	m.Flags().IntVar(&reportInterval, "interval", 10, "Interval of outputting measurements in seconds")
 }
 
 func newLoadCommand() *cobra.Command {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -188,7 +188,7 @@ func (c *Client) Run(ctx context.Context) {
 		// finish warming up
 		measurement.EnableWarmUp(false)
 
-		dur := c.p.GetInt64("measurement.interval", 10)
+		dur := c.p.GetInt64(prop.LogInterval, 10)
 		t := time.NewTicker(time.Duration(dur) * time.Second)
 		defer t.Stop()
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -106,4 +106,6 @@ const (
 
 	KeyPrefix        = "keyprefix"
 	KeyPrefixDefault = "user"
+
+	LogInterval = "measurement.interval"
 )


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

Support to indicate report interval by arguments.