### PR TITLE
adding new param of BatchPut makes test could pass

### DIFF
--- a/db/tikv/raw.go
+++ b/db/tikv/raw.go
@@ -153,7 +153,7 @@ func (db *rawDB) BatchUpdate(ctx context.Context, table string, keys []string, v
 		}
 		rawValues = append(rawValues, rawData)
 	}
-	return db.db.BatchPut(ctx, rawKeys, rawValues)
+	return db.db.BatchPut(ctx, rawKeys, rawValues, nil)
 }
 
 func (db *rawDB) Insert(ctx context.Context, table string, key string, values map[string][]byte) error {
@@ -180,7 +180,7 @@ func (db *rawDB) BatchInsert(ctx context.Context, table string, keys []string, v
 		}
 		rawValues = append(rawValues, rawData)
 	}
-	return db.db.BatchPut(ctx, rawKeys, rawValues)
+	return db.db.BatchPut(ctx, rawKeys, rawValues, nil)
 }
 
 func (db *rawDB) Delete(ctx context.Context, table string, key string) error {


### PR DESCRIPTION
BatchPut has add ttls param, so we must add this param when calling client-go

https://github.com/pingcap/kvproto/blob/master/proto/kvrpcpb.proto#L465
https://github.com/tikv/client-go/pull/298

Signed-off-by: tangjk <tangjiankun1226@gmail.com>