### PR TITLE
support batch for mysql

### DIFF
--- a/db/mysql/db.go
+++ b/db/mysql/db.go
@@ -226,6 +226,37 @@ func (db *mysqlDB) Read(ctx context.Context, table string, key string, fields []
 	return rows[0], nil
 }
 
+func (db *mysqlDB) BatchRead(ctx context.Context, table string, keys []string, fields []string) ([]map[string][]byte, error) {
+	args := make([]interface{}, 0, len(keys))
+	buf := db.bufPool.Get()
+	defer db.bufPool.Put(buf)
+	if len(fields) == 0 {
+		buf.WriteString(fmt.Sprintf(`SELECT * FROM %s %s WHERE YCSB_KEY IN (`, table, db.forceIndexKeyword))
+	} else {
+		buf.WriteString(fmt.Sprintf(`SELECT %s FROM %s %s WHERE YCSB_KEY IN (`, strings.Join(fields, ","), table, db.forceIndexKeyword))
+	}
+	for i, key := range keys {
+		buf.WriteByte('?')
+		if i < len(keys)-1 {
+			buf.WriteByte(',')
+		}
+		args = append(args, key)
+	}
+	buf.WriteByte(')')
+
+	query := buf.String()
+	rows, err := db.queryRows(ctx, query, len(keys), args...)
+	db.clearCacheIfFailed(ctx, query, err)
+
+	if err != nil {
+		return nil, err
+	} else if len(rows) == 0 {
+		return nil, nil
+	}
+
+	return rows, nil
+}
+
 func (db *mysqlDB) Scan(ctx context.Context, table string, startKey string, count int, fields []string) ([]map[string][]byte, error) {
 	var query string
 	if len(fields) == 0 {
@@ -283,6 +314,17 @@ func (db *mysqlDB) Update(ctx context.Context, table string, key string, values 
 	return db.execQuery(ctx, buf.String(), args...)
 }
 
+func (db *mysqlDB) BatchUpdate(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	// mysql does not support BatchUpdate, fallback to Update like dbwrapper.go
+	for i := range keys {
+		err := db.Update(ctx, table, keys[i], values[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (db *mysqlDB) Insert(ctx context.Context, table string, key string, values map[string][]byte) error {
 	args := make([]interface{}, 0, 1+len(values))
 	args = append(args, key)
@@ -311,10 +353,66 @@ func (db *mysqlDB) Insert(ctx context.Context, table string, key string, values 
 	return db.execQuery(ctx, buf.String(), args...)
 }
 
+func (db *mysqlDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	args := make([]interface{}, 0, (1+len(values))*len(keys))
+	buf := db.bufPool.Get()
+	defer db.bufPool.Put(buf)
+	buf.WriteString("INSERT IGNORE INTO ")
+	buf.WriteString(table)
+	buf.WriteString(" (YCSB_KEY")
+
+	valueString := strings.Builder{}
+	valueString.WriteString("(?")
+	pairs := util.NewFieldPairs(values[0])
+	for _, p := range pairs {
+		buf.WriteString(" ,")
+		buf.WriteString(p.Field)
+
+		valueString.WriteString(" ,?")
+	}
+	// Example: INSERT IGNORE INTO table ([columns]) VALUES
+	buf.WriteString(") VALUES ")
+	// Example: (?, ?, ?, ....)
+	valueString.WriteByte(')')
+	valueStrings := make([]string, 0, len(keys))
+	for range keys {
+		valueStrings = append(valueStrings, valueString.String())
+	}
+	// Example: INSERT IGNORE INTO table ([columns]) VALUES (?, ?, ?...), (?, ?, ?), ...
+	buf.WriteString(strings.Join(valueStrings, ","))
+
+	for i, key := range keys {
+		args = append(args, key)
+		pairs := util.NewFieldPairs(values[i])
+		for _, p := range pairs {
+			args = append(args, p.Value)
+		}
+	}
+
+	return db.execQuery(ctx, buf.String(), args...)
+}
+
 func (db *mysqlDB) Delete(ctx context.Context, table string, key string) error {
 	query := fmt.Sprintf(`DELETE FROM %s WHERE YCSB_KEY = ?`, table)
 
 	return db.execQuery(ctx, query, key)
+}
+
+func (db *mysqlDB) BatchDelete(ctx context.Context, table string, keys []string) error {
+	args := make([]interface{}, 0, len(keys))
+	buf := db.bufPool.Get()
+	defer db.bufPool.Put(buf)
+	buf.WriteString(fmt.Sprintf("DELETE FROM %s WHERE YSCB_KEY IN (", table))
+	for i, key := range keys {
+		buf.WriteByte('?')
+		if i < len(keys)-1 {
+			buf.WriteByte(',')
+		}
+		args = append(args, key)
+	}
+	buf.WriteByte(')')
+
+	return db.execQuery(ctx, buf.String(), args...)
 }
 
 func (db *mysqlDB) Analyze(ctx context.Context, table string) error {


### PR DESCRIPTION
This PR add batch support for mysql, which was motivated by using batch insert to accelerate the load process during benchmarks.

This commit was tested in benchmarks with 3 billions rows. Also, I did some smoke tests locally:

```
> tiup playground

> ./bin/go-ycsb load mysql -P workloads/workloada -p mysql.host=127.0.0.1 -p mysql.port=4000
***************** properties *****************
"readproportion"="0.5"
"batch.size"="50"
"recordcount"="100000"
"dotransactions"="false"
"scanproportion"="0"
"workload"="core"
"operationcount"="100000"
"mysql.host"="127.0.0.1"
"updateproportion"="0.5"
"insertproportion"="0"
"requestdistribution"="uniform"
"readallfields"="true"
"mysql.port"="4000"
**********************************************
BATCH_INSERT - Takes(s): 9.8, Count: 1807, OPS: 183.7, Avg(us): 4842, Min(us): 4011, Max(us): 63910, 99th(us): 8000, 99.9th(us): 33000, 99.99th(us): 57000
Run finished, takes 17.490709788s
BATCH_INSERT - Takes(s): 17.3, Count: 2000, OPS: 115.4, Avg(us): 4827, Min(us): 4011, Max(us): 63910, 99th(us): 8000, 99.9th(us): 33000, 99.99th(us): 64000

> ./bin/go-ycsb run mysql -P workloads/workloada -p mysql.host=127.0.0.1 -p mysql.port=4000
***************** properties *****************
"requestdistribution"="uniform"
"workload"="core"
"scanproportion"="0"
"updateproportion"="0.5"
"dotransactions"="true"
"operationcount"="100000"
"readallfields"="true"
"recordcount"="100000"
"batch.size"="50"
"insertproportion"="0"
"mysql.port"="4000"
"readproportion"="0.5"
"mysql.host"="127.0.0.1"
**********************************************
BATCH_READ - Takes(s): 9.9, Count: 215, OPS: 21.7, Avg(us): 1709, Min(us): 1404, Max(us): 3159, 99th(us): 3000, 99.9th(us): 4000, 99.99th(us): 4000
BATCH_UPDATE - Takes(s): 9.9, Count: 148, OPS: 14.9, Avg(us): 64719, Min(us): 60583, Max(us): 117298, 99th(us): 116000, 99.9th(us): 118000, 99.99th(us): 118000
........
```

Signed-off-by: Aylei <rayingecho@gmail.com>