### PR TITLE
*: move create table to mysql to support tidb cluster index 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Common configurations:
 |verbose|false|Output the execution query|
 |debug.pprof|":6060"|Go debug profile address|
 
-### MySQL
+### MySQL & TiDB
 
 |field|default value|description|
 |-|-|-|
@@ -97,6 +97,7 @@ Common configurations:
 |mysql.user|"root"|MySQL User|
 |mysql.password||MySQL Password|
 |mysql.db|"test"|MySQL Database|
+|tidb.cluster_index|true|Whether to use cluster index, for TiDB only|
 
 
 ### TiKV

--- a/db/aerospike/db.go
+++ b/db/aerospike/db.go
@@ -2,7 +2,6 @@ package aerospike
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 
 	as "github.com/aerospike/aerospike-client-go"
@@ -24,10 +23,6 @@ type aerospikedb struct {
 // Close closes the database layer.
 func (adb *aerospikedb) Close() error {
 	adb.client.Close()
-	return nil
-}
-
-func (db *aerospikedb) ToSqlDB() *sql.DB {
 	return nil
 }
 

--- a/db/badger/db.go
+++ b/db/badger/db.go
@@ -15,7 +15,6 @@ package badger
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 
@@ -129,10 +128,6 @@ func getOptions(p *properties.Properties) badger.Options {
 	}
 
 	return opts
-}
-
-func (db *badgerDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *badgerDB) Close() error {

--- a/db/basic/db.go
+++ b/db/basic/db.go
@@ -33,7 +33,6 @@ package basic
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"fmt"
 	"math/rand"
 	"time"
@@ -85,10 +84,6 @@ func (db *basicDB) delay(ctx context.Context, state *basicState) {
 	case <-time.After(delayTime):
 	case <-ctx.Done():
 	}
-}
-
-func (db *basicDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *basicDB) InitThread(ctx context.Context, _ int, _ int) context.Context {

--- a/db/boltdb/db.go
+++ b/db/boltdb/db.go
@@ -30,7 +30,6 @@ package boltdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 
@@ -108,10 +107,6 @@ func getOptions(p *properties.Properties) boltOptions {
 
 func (db *boltDB) Close() error {
 	return db.db.Close()
-}
-
-func (db *boltDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *boltDB) InitThread(ctx context.Context, _ int, _ int) context.Context {

--- a/db/cassandra/db.go
+++ b/db/cassandra/db.go
@@ -16,7 +16,6 @@ package cassandra
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -132,10 +131,6 @@ func (db *cassandraDB) createTable() error {
 
 	err := db.session.Query(buf.String()).Exec()
 	return err
-}
-
-func (db *cassandraDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *cassandraDB) Close() error {

--- a/db/foundationdb/db.go
+++ b/db/foundationdb/db.go
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build foundationdb
 // +build foundationdb
 
 package foundationdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
@@ -57,10 +57,6 @@ func createDB(p *properties.Properties) (ycsb.DB, error) {
 		r:       util.NewRowCodec(p),
 		bufPool: bufPool,
 	}, nil
-}
-
-func (db *fDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *fDB) Close() error {

--- a/db/minio/db.go
+++ b/db/minio/db.go
@@ -3,7 +3,6 @@ package minio
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"io/ioutil"
 
 	"github.com/magiconair/properties"
@@ -36,10 +35,6 @@ func (c minioCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 
 type minioDB struct {
 	db *minio.Client
-}
-
-func (db *minioDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 // Close closes the database layer.

--- a/db/mongodb/db.go
+++ b/db/mongodb/db.go
@@ -2,7 +2,6 @@ package mongodb
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 
@@ -29,10 +28,6 @@ const (
 type mongoDB struct {
 	cli *mongo.Client
 	db  *mongo.Database
-}
-
-func (db *mongoDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (m *mongoDB) Close() error {

--- a/db/pegasus/db.go
+++ b/db/pegasus/db.go
@@ -45,7 +45,6 @@ package pegasus
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	_ "net/http/pprof"
 	"strings"
@@ -65,10 +64,6 @@ var (
 type pegasusDB struct {
 	client   *pegasus2.Client
 	sessions []pegasus.TableConnector
-}
-
-func (db *pegasusDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *pegasusDB) InitThread(ctx context.Context, threadId int, _ int) context.Context {

--- a/db/pg/db.go
+++ b/db/pg/db.go
@@ -130,10 +130,6 @@ func (db *pgDB) createTable() error {
 	return err
 }
 
-func (db *pgDB) ToSqlDB() *sql.DB {
-	return nil
-}
-
 func (db *pgDB) Close() error {
 	if db.db == nil {
 		return nil

--- a/db/redis/db.go
+++ b/db/redis/db.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"context"
 	"crypto/tls"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -28,10 +27,6 @@ type redisClient interface {
 type redis struct {
 	client redisClient
 	mode   string
-}
-
-func (db *redis) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (r *redis) Close() error {

--- a/db/rocksdb/db.go
+++ b/db/rocksdb/db.go
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build rocksdb
 // +build rocksdb
 
 package rocksdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 
@@ -161,10 +161,6 @@ func getOptions(p *properties.Properties) *gorocksdb.Options {
 	opts.SetBlockBasedTableFactory(getTableOptions(p))
 
 	return opts
-}
-
-func (db *rocksDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *rocksDB) Close() error {

--- a/db/spanner/db.go
+++ b/db/spanner/db.go
@@ -16,7 +16,6 @@ package spanner
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 	"os/user"
@@ -224,10 +223,6 @@ func (db *spannerDB) Close() error {
 	}
 
 	db.client.Close()
-	return nil
-}
-
-func (db *spannerDB) ToSqlDB() *sql.DB {
 	return nil
 }
 

--- a/db/sqlite/db.go
+++ b/db/sqlite/db.go
@@ -113,10 +113,6 @@ func (db *sqliteDB) createTable() error {
 	return err
 }
 
-func (db *sqliteDB) ToSqlDB() *sql.DB {
-	return nil
-}
-
 func (db *sqliteDB) Close() error {
 	if db.db == nil {
 		return nil

--- a/db/tikv/raw.go
+++ b/db/tikv/raw.go
@@ -15,7 +15,6 @@ package tikv
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
@@ -61,10 +60,6 @@ func (db *rawDB) CleanupThread(ctx context.Context) {
 
 func (db *rawDB) getRowKey(table string, key string) []byte {
 	return util.Slice(fmt.Sprintf("%s:%s", table, key))
-}
-
-func (db *rawDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *rawDB) Read(ctx context.Context, table string, key string, fields []string) (map[string][]byte, error) {

--- a/db/tikv/txn.go
+++ b/db/tikv/txn.go
@@ -15,10 +15,10 @@ package tikv
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"github.com/tikv/client-go/v2/txnkv"
 	"strings"
+
+	"github.com/tikv/client-go/v2/txnkv"
 
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/util"
@@ -60,10 +60,6 @@ func (db *txnDB) CleanupThread(ctx context.Context) {
 
 func (db *txnDB) getRowKey(table string, key string) []byte {
 	return util.Slice(fmt.Sprintf("%s:%s", table, key))
-}
-
-func (db *txnDB) ToSqlDB() *sql.DB {
-	return nil
 }
 
 func (db *txnDB) Read(ctx context.Context, table string, key string, fields []string) (map[string][]byte, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -202,11 +202,6 @@ func (c *Client) Run(ctx context.Context) {
 		}
 	}()
 
-	if err := c.workload.Init(c.db); err != nil {
-		fmt.Printf("Initialize workload fail: %v\n", err)
-		return
-	}
-
 	for i := 0; i < threadCount; i++ {
 		go func(threadId int) {
 			defer wg.Done()

--- a/pkg/client/dbwrapper.go
+++ b/pkg/client/dbwrapper.go
@@ -15,7 +15,6 @@ package client
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
@@ -36,10 +35,6 @@ func measure(start time.Time, op string, err error) {
 	}
 
 	measurement.Measure(op, lan)
-}
-
-func (db DbWrapper) ToSqlDB() *sql.DB {
-	return db.DB.ToSqlDB()
 }
 
 func (db DbWrapper) Close() error {

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -133,37 +133,6 @@ func createOperationGenerator(p *properties.Properties) *generator.Discrete {
 	return operationChooser
 }
 
-// Init --create all schemas for ycsb workload
-func (c *core) Init(db ycsb.DB) error {
-	// need to redesign the relation btw workload and db interface later.
-	sqlDB := db.ToSqlDB()
-	if sqlDB != nil {
-		tableName := c.p.GetString(prop.TableName, prop.TableNameDefault)
-		if c.p.GetBool(prop.DropData, prop.DropDataDefault) && !c.p.GetBool(prop.DoTransactions, true) {
-			if _, err := sqlDB.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)); err != nil {
-				return err
-			}
-		}
-
-		fieldCount := c.p.GetInt64(prop.FieldCount, prop.FieldCountDefault)
-		fieldLength := c.p.GetInt64(prop.FieldLength, prop.FieldLengthDefault)
-
-		buf := new(bytes.Buffer)
-		s := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (YCSB_KEY VARCHAR(64) PRIMARY KEY", tableName)
-		buf.WriteString(s)
-
-		for i := int64(0); i < fieldCount; i++ {
-			buf.WriteString(fmt.Sprintf(", FIELD%d VARCHAR(%d)", i, fieldLength))
-		}
-
-		buf.WriteString(");")
-
-		_, err := sqlDB.Exec(buf.String())
-		return err
-	}
-	return nil
-}
-
 // Load implements the Workload Load interface.
 func (c *core) Load(ctx context.Context, db ycsb.DB, totalCount int64) error {
 	return nil

--- a/pkg/ycsb/db.go
+++ b/pkg/ycsb/db.go
@@ -15,7 +15,6 @@ package ycsb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/magiconair/properties"
@@ -28,9 +27,6 @@ type DBCreator interface {
 
 // DB is the layer to access the database to be benchmarked.
 type DB interface {
-	// ToSqlDB returns a sql.DB if it's possible.
-	ToSqlDB() *sql.DB
-
 	// Close closes the database layer.
 	Close() error
 

--- a/pkg/ycsb/workload.go
+++ b/pkg/ycsb/workload.go
@@ -27,9 +27,6 @@ type WorkloadCreator interface {
 
 // Workload defines different workload for YCSB.
 type Workload interface {
-	// Initialize the workload.
-	Init(db DB) error
-
 	// Close closes the workload.
 	Close() error
 

--- a/workloads/workloada
+++ b/workloads/workloada
@@ -28,8 +28,8 @@ workload=core
 
 readallfields=true
 
-readproportion=0.5
-updateproportion=0.5
+readproportion=1
+updateproportion=0
 scanproportion=0
 insertproportion=0
 

--- a/workloads/workloada
+++ b/workloads/workloada
@@ -28,8 +28,8 @@ workload=core
 
 readallfields=true
 
-readproportion=1
-updateproportion=0
+readproportion=0.5
+updateproportion=0.5
 scanproportion=0
 insertproportion=0
 


### PR DESCRIPTION
- Now each DB module implements its own CreateTable logic, so let MySQL module does this too
- Support TiDB cluster index 
- Remove unnecessary interface `ToSqlDB` 

A simple test for 100% read is below:

```bash
# non cluster index
READ   - Takes(s): 0.3, Count: 1000, OPS: 3426.4, Avg(us): 291, Min(us): 223, Max(us): 2185, 99th(us): 553, 99.9th(us): 1520, 99.99th(us): 2185

# cluster index
READ   - Takes(s): 0.2, Count: 1000, OPS: 6335.8, Avg(us): 157, Min(us): 105, Max(us): 2181, 99th(us): 405, 99.9th(us): 1240, 99.99th(us): 2181
```