### PR TITLE
Automatically publish Go binaries to Github Release Assets through Github Action.

### DIFF
--- a/.github/workflows/github-release-publish.yml
+++ b/.github/workflows/github-release-publish.yml
@@ -1,0 +1,26 @@
+# .github/workflows/github-release-publish.yml
+name: Publish artifacts to github release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@v1.28
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          binary_name: "./bin/go-ycsb"
+          sha256sum: true
+          asset_name: go-ycsb-${{ matrix.goos }}-${{ matrix.goarch }}
+          build_command: "make"

--- a/README.md
+++ b/README.md
@@ -9,12 +9,35 @@ go-ycsb is a Go port of [YCSB](https://github.com/brianfrankcooper/YCSB). It ful
 
 ## Getting Started
 
+### Download
+
+https://github.com/pingcap/go-ycsb/releases/latest
+
+**Linux**
+```
+wget -c https://github.com/pingcap/go-ycsb/releases/latest/download/go-ycsb-linux-amd64.tar.gz -O - | tar -xz
+
+# give it a try
+./go-ycsb --help
+```
+
+**OSX**
+```
+wget -c https://github.com/pingcap/go-ycsb/releases/latest/download/go-ycsb-darwin-amd64.tar.gz -O - | tar -xz
+
+# give it a try
+./go-ycsb --help
+```
+
+### Building from source
+
 ```bash
 git clone https://github.com/pingcap/go-ycsb.git
 cd go-ycsb
 make
 
-./bin/go-ycsb
+# give it a try
+./bin/go-ycsb  --help
 ```
 
 Notice:
@@ -25,7 +48,7 @@ Notice:
 
 ## Usage 
 
-Mostly, we can start from the offical document [Running-a-Workload](https://github.com/brianfrankcooper/YCSB/wiki/Running-a-Workload).
+Mostly, we can start from the official document [Running-a-Workload](https://github.com/brianfrankcooper/YCSB/wiki/Running-a-Workload).
 
 ### Shell
 


### PR DESCRIPTION
This PR enables an easier getting started way without even needing go on the client machine. 
As soon the project releases a version this action publishes released artifacts for linux/darwin arm64/amd64 variations. 

You can confirm the expected release artifacts produced at: https://github.com/filipecosta90/go-ycsb/releases/latest

Sample test for Linux:
```bash
wget -c https://github.com/filipecosta90/go-ycsb/releases/latest/download/go-ycsb-linux-amd64.tar.gz -O - | tar -xz

# give it a try
./go-ycsb --help
```