### PR TITLE
Fix SQLite and add support for mvSQLite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 FDB_CHECK := $(shell command -v fdbcli 2> /dev/null)
 ROCKSDB_CHECK := $(shell echo "int main() { return 0; }" | gcc -lrocksdb -x c++ -o /dev/null - 2>/dev/null; echo $$?)
+SQLITE_CHECK := $(shell echo "int main() { return 0; }" | gcc -lsqlite3 -o /dev/null - 2>/dev/null; echo $$?)
 
 TAGS =
 
 ifdef FDB_CHECK
 	TAGS += foundationdb
+endif
+
+ifdef SQLITE_CHECK
+	TAGS += libsqlite3
 endif
 
 ifeq ($(ROCKSDB_CHECK), 0)

--- a/db/foundationdb/db.go
+++ b/db/foundationdb/db.go
@@ -153,7 +153,7 @@ func (db *fDB) Update(ctx context.Context, table string, key string, values map[
 		buf := db.bufPool.Get()
 		defer db.bufPool.Put(buf)
 
-		buf, err := db.r.Encode(buf, data)
+		buf, err = db.r.Encode(buf, data)
 		if err != nil {
 			return nil, err
 		}

--- a/db/sqlite/db.go
+++ b/db/sqlite/db.go
@@ -21,31 +21,36 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pingcap/go-ycsb/pkg/prop"
 	"github.com/pingcap/go-ycsb/pkg/util"
 
 	"github.com/magiconair/properties"
 	// sqlite package
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
 // Sqlite properties
 const (
-	sqliteDBPath      = "sqlite.db"
-	sqliteMode        = "sqlite.mode"
-	sqliteJournalMode = "sqlite.journalmode"
-	sqliteCache       = "sqlite.cache"
+	sqliteDBPath       = "sqlite.db"
+	sqliteMode         = "sqlite.mode"
+	sqliteJournalMode  = "sqlite.journalmode"
+	sqliteCache        = "sqlite.cache"
+	sqliteMaxOpenConns = "sqlite.maxopenconns"
+	sqliteMaxIdleConns = "sqlite.maxidleconns"
+	sqliteOptimistic   = "sqlite.optimistic"
 )
 
 type sqliteCreator struct {
 }
 
 type sqliteDB struct {
-	p       *properties.Properties
-	db      *sql.DB
-	verbose bool
+	p          *properties.Properties
+	db         *sql.DB
+	verbose    bool
+	optimistic bool
 
 	bufPool *util.BufPool
 }
@@ -63,6 +68,8 @@ func (c sqliteCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 	mode := p.GetString(sqliteMode, "rwc")
 	journalMode := p.GetString(sqliteJournalMode, "WAL")
 	cache := p.GetString(sqliteCache, "shared")
+	maxOpenConns := p.GetInt(sqliteMaxOpenConns, 1)
+	maxIdleConns := p.GetInt(sqliteMaxIdleConns, 2)
 
 	v := url.Values{}
 	v.Set("cache", cache)
@@ -75,8 +82,10 @@ func (c sqliteCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 		return nil, err
 	}
 
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
 
+	d.optimistic = p.GetBool(sqliteOptimistic, false)
 	d.verbose = p.GetBool(prop.Verbose, prop.VerboseDefault)
 	d.db = db
 
@@ -129,12 +138,36 @@ func (db *sqliteDB) CleanupThread(ctx context.Context) {
 
 }
 
-func (db *sqliteDB) queryRows(ctx context.Context, query string, count int, args ...interface{}) ([]map[string][]byte, error) {
+func (db *sqliteDB) optimisticTx(ctx context.Context, f func(tx *sql.Tx) error) error {
+	for {
+		tx, err := db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		err = f(tx)
+		if err == nil {
+			err = tx.Commit()
+			if err != nil && db.optimistic {
+				if err, ok := err.(sqlite3.Error); ok && (err.Code == sqlite3.ErrBusy ||
+					err.ExtendedCode == sqlite3.ErrIoErrUnlock) {
+					time.Sleep(5 * time.Millisecond)
+					continue
+				}
+			}
+			return err
+		}
+
+		tx.Rollback()
+		return err
+	}
+}
+
+func (db *sqliteDB) doQueryRows(ctx context.Context, tx *sql.Tx, query string, count int, args ...interface{}) ([]map[string][]byte, error) {
 	if db.verbose {
 		fmt.Printf("%s %v\n", query, args)
 	}
 
-	rows, err := db.db.QueryContext(ctx, query, args...)
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +200,7 @@ func (db *sqliteDB) queryRows(ctx context.Context, query string, count int, args
 	return vs, rows.Err()
 }
 
-func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields []string) (map[string][]byte, error) {
+func (db *sqliteDB) doRead(ctx context.Context, tx *sql.Tx, table string, key string, fields []string) (map[string][]byte, error) {
 	var query string
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY = ?`, table)
@@ -175,7 +208,7 @@ func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields [
 		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY = ?`, strings.Join(fields, ","), table)
 	}
 
-	rows, err := db.queryRows(ctx, query, 1, key)
+	rows, err := db.doQueryRows(ctx, tx, query, 1, key)
 
 	if err != nil {
 		return nil, err
@@ -186,7 +219,17 @@ func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields [
 	return rows[0], nil
 }
 
-func (db *sqliteDB) Scan(ctx context.Context, table string, startKey string, count int, fields []string) ([]map[string][]byte, error) {
+func (db *sqliteDB) Read(ctx context.Context, table string, key string, fields []string) (map[string][]byte, error) {
+	var output map[string][]byte
+	err := db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		res, err := db.doRead(ctx, tx, table, key, fields)
+		output = res
+		return err
+	})
+	return output, err
+}
+
+func (db *sqliteDB) doScan(ctx context.Context, tx *sql.Tx, table string, startKey string, count int, fields []string) ([]map[string][]byte, error) {
 	var query string
 	if len(fields) == 0 {
 		query = fmt.Sprintf(`SELECT * FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, table)
@@ -194,25 +237,22 @@ func (db *sqliteDB) Scan(ctx context.Context, table string, startKey string, cou
 		query = fmt.Sprintf(`SELECT %s FROM %s WHERE YCSB_KEY >= ? LIMIT ?`, strings.Join(fields, ","), table)
 	}
 
-	rows, err := db.queryRows(ctx, query, count, startKey, count)
+	rows, err := db.doQueryRows(ctx, tx, query, count, startKey, count)
 
 	return rows, err
 }
 
-func (db *sqliteDB) execQuery(ctx context.Context, query string, args ...interface{}) error {
-	if db.verbose {
-		fmt.Printf("%s %v\n", query, args)
-	}
-
-	_, err := db.db.ExecContext(ctx, query, args)
-	if err != nil {
+func (db *sqliteDB) Scan(ctx context.Context, table string, startKey string, count int, fields []string) ([]map[string][]byte, error) {
+	var output []map[string][]byte
+	err := db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		res, err := db.doScan(ctx, tx, table, startKey, count, fields)
+		output = res
 		return err
-	}
-
-	return err
+	})
+	return output, err
 }
 
-func (db *sqliteDB) Update(ctx context.Context, table string, key string, values map[string][]byte) error {
+func (db *sqliteDB) doUpdate(ctx context.Context, tx *sql.Tx, table string, key string, values map[string][]byte) error {
 	buf := bytes.NewBuffer(db.bufPool.Get())
 	defer func() {
 		db.bufPool.Put(buf.Bytes())
@@ -239,10 +279,17 @@ func (db *sqliteDB) Update(ctx context.Context, table string, key string, values
 
 	args = append(args, key)
 
-	return db.execQuery(ctx, buf.String(), args...)
+	_, err := tx.ExecContext(ctx, buf.String(), args...)
+	return err
 }
 
-func (db *sqliteDB) Insert(ctx context.Context, table string, key string, values map[string][]byte) error {
+func (db *sqliteDB) Update(ctx context.Context, table string, key string, values map[string][]byte) error {
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		return db.doUpdate(ctx, tx, table, key, values)
+	})
+}
+
+func (db *sqliteDB) doInsert(ctx context.Context, tx *sql.Tx, table string, key string, values map[string][]byte) error {
 	args := make([]interface{}, 0, 1+len(values))
 	args = append(args, key)
 
@@ -269,15 +316,80 @@ func (db *sqliteDB) Insert(ctx context.Context, table string, key string, values
 
 	buf.WriteByte(')')
 
-	return db.execQuery(ctx, buf.String(), args...)
+	_, err := tx.ExecContext(ctx, buf.String(), args...)
+	if err != nil && db.verbose {
+		fmt.Printf("error(doInsert): %s: %+v\n", buf.String(), err)
+	}
+	return err
+}
+
+func (db *sqliteDB) Insert(ctx context.Context, table string, key string, values map[string][]byte) error {
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error { return db.doInsert(ctx, tx, table, key, values) })
+}
+
+func (db *sqliteDB) doDelete(ctx context.Context, tx *sql.Tx, table string, key string) error {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE YCSB_KEY = ?`, table)
+	_, err := tx.ExecContext(ctx, query, key)
+	return err
 }
 
 func (db *sqliteDB) Delete(ctx context.Context, table string, key string) error {
-	query := fmt.Sprintf(`DELETE FROM %s WHERE YCSB_KEY = ?`, table)
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error { return db.doDelete(ctx, tx, table, key) })
+}
 
-	return db.execQuery(ctx, query, key)
+func (db *sqliteDB) BatchInsert(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		for i := 0; i < len(keys); i++ {
+			err := db.doInsert(ctx, tx, table, keys[i], values[i])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (db *sqliteDB) BatchRead(ctx context.Context, table string, keys []string, fields []string) ([]map[string][]byte, error) {
+	var output []map[string][]byte
+	err := db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		for i := 0; i < len(keys); i++ {
+			res, err := db.doRead(ctx, tx, table, keys[i], fields)
+			if err != nil {
+				return err
+			}
+			output = append(output, res)
+		}
+		return nil
+	})
+	return output, err
+}
+
+func (db *sqliteDB) BatchUpdate(ctx context.Context, table string, keys []string, values []map[string][]byte) error {
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		for i := 0; i < len(keys); i++ {
+			err := db.doUpdate(ctx, tx, table, keys[i], values[i])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (db *sqliteDB) BatchDelete(ctx context.Context, table string, keys []string) error {
+	return db.optimisticTx(ctx, func(tx *sql.Tx) error {
+		for i := 0; i < len(keys); i++ {
+			err := db.doDelete(ctx, tx, table, keys[i])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func init() {
 	ycsb.RegisterDBCreator("sqlite", sqliteCreator{})
 }
+
+var _ ycsb.BatchDB = (*sqliteDB)(nil)


### PR DESCRIPTION
Previously the SQLite backend didn't work because of a missing spread operator in `execQuery`.

This PR also added a few new options and mechanisms to support [mvSQLite](https://github.com/losfair/mvsqlite):

- Configurable `MaxOpenConns` and `MaxIdleConns`
- Optimistic transactions and automatic retry