### PR TITLE
Add CSV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Available Commands:
 - etcd
 - DynamoDB
 
+## Output configuration
+
+|field|default value|description|
+|-|-|-|
+|measurementtype|"histogram"|The mechanism for recording measurements, one of `histogram`, `raw` or `csv`|
+|measurement.raw.output_file|""|File to write output to, default writes to stdout|
+
 ## Database Configuration
 
 You can pass the database configurations through `-p field=value` in the command line directly.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Available Commands:
 |field|default value|description|
 |-|-|-|
 |measurementtype|"histogram"|The mechanism for recording measurements, one of `histogram`, `raw` or `csv`|
-|measurement.raw.output_file|""|File to write output to, default writes to stdout|
+|measurement.output_file|""|File to write output to, default writes to stdout|
 
 ## Database Configuration
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -195,7 +195,7 @@ func (c *Client) Run(ctx context.Context) {
 		for {
 			select {
 			case <-t.C:
-				measurement.Output()
+				measurement.Summary()
 			case <-measureCtx.Done():
 				return
 			}

--- a/pkg/client/dbwrapper.go
+++ b/pkg/client/dbwrapper.go
@@ -30,11 +30,11 @@ type DbWrapper struct {
 func measure(start time.Time, op string, err error) {
 	lan := time.Now().Sub(start)
 	if err != nil {
-		measurement.Measure(fmt.Sprintf("%s_ERROR", op), lan)
+		measurement.Measure(fmt.Sprintf("%s_ERROR", op), start, lan)
 		return
 	}
 
-	measurement.Measure(op, lan)
+	measurement.Measure(op, start, lan)
 }
 
 func (db DbWrapper) Close() error {

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -55,11 +55,3 @@ func (c *csvs) Output(w io.Writer) error {
 	}
 	return nil
 }
-
-func (c *csvs) OpNames() []string {
-	names := make([]string, 0, len(c.csvs))
-	for op := range c.csvs {
-		names = append(names, op)
-	}
-	return names
-}

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -45,3 +45,7 @@ func (c *csvs) Output(w io.Writer) error {
 	}
 	return nil
 }
+
+func (c *csvs) Summary() {
+	// do nothing as csvs don't keep a summary
+}

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
@@ -17,13 +16,11 @@ type csventry struct {
 }
 
 type csvs struct {
-	p    *properties.Properties
 	csvs map[string][]csventry
 }
 
-func InitCSV(p *properties.Properties) *csvs {
+func InitCSV() *csvs {
 	return &csvs{
-		p:    p,
 		csvs: make(map[string][]csventry, 16),
 	}
 }

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -16,25 +16,25 @@ type csventry struct {
 }
 
 type csvs struct {
-	csvs map[string][]csventry
+	opCsv map[string][]csventry
 }
 
 func InitCSV() *csvs {
 	return &csvs{
-		csvs: make(map[string][]csventry, 16),
+		opCsv: make(map[string][]csventry),
 	}
 }
 
 func (c *csvs) Info() map[string]ycsb.MeasurementInfo {
-	info := make(map[string]ycsb.MeasurementInfo, len(c.csvs))
-	for op, _ := range c.csvs {
+	info := make(map[string]ycsb.MeasurementInfo, len(c.opCsv))
+	for op, _ := range c.opCsv {
 		info[op] = nil
 	}
 	return info
 }
 
 func (c *csvs) Measure(op string, start time.Time, lan time.Duration) {
-	c.csvs[op] = append(c.csvs[op], csventry{
+	c.opCsv[op] = append(c.opCsv[op], csventry{
 		start_us:   start.UnixMicro(),
 		latency_us: lan.Microseconds(),
 	})
@@ -45,7 +45,7 @@ func (c *csvs) Output(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	for op, entries := range c.csvs {
+	for op, entries := range c.opCsv {
 		for _, entry := range entries {
 			_, err := fmt.Fprintf(w, "%s,%d,%d\n", op, entry.start_us, entry.latency_us)
 			if err != nil {

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"time"
-
-	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
 type csventry struct {
@@ -23,14 +21,6 @@ func InitCSV() *csvs {
 	return &csvs{
 		opCsv: make(map[string][]csventry),
 	}
-}
-
-func (c *csvs) Info() map[string]ycsb.MeasurementInfo {
-	info := make(map[string]ycsb.MeasurementInfo, len(c.opCsv))
-	for op, _ := range c.opCsv {
-		info[op] = nil
-	}
-	return info
 }
 
 func (c *csvs) Measure(op string, start time.Time, lan time.Duration) {

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -8,9 +8,9 @@ import (
 
 type csventry struct {
 	// start time of the operation in us from unix epoch
-	start_us int64
+	startUs int64
 	// latency of the operation in us
-	latency_us int64
+	latencyUs int64
 }
 
 type csvs struct {
@@ -25,8 +25,8 @@ func InitCSV() *csvs {
 
 func (c *csvs) Measure(op string, start time.Time, lan time.Duration) {
 	c.opCsv[op] = append(c.opCsv[op], csventry{
-		start_us:   start.UnixMicro(),
-		latency_us: lan.Microseconds(),
+		startUs:   start.UnixMicro(),
+		latencyUs: lan.Microseconds(),
 	})
 }
 
@@ -37,7 +37,7 @@ func (c *csvs) Output(w io.Writer) error {
 	}
 	for op, entries := range c.opCsv {
 		for _, entry := range entries {
-			_, err := fmt.Fprintf(w, "%s,%d,%d\n", op, entry.start_us, entry.latency_us)
+			_, err := fmt.Fprintf(w, "%s,%d,%d\n", op, entry.startUs, entry.latencyUs)
 			if err != nil {
 				return err
 			}

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -1,0 +1,44 @@
+package measurement
+
+import (
+	"time"
+
+	"github.com/magiconair/properties"
+	"github.com/pingcap/go-ycsb/pkg/ycsb"
+)
+
+type csventry struct {
+	op    string
+	start time.Time
+	lan   time.Duration
+}
+
+type csv struct {
+	p    *properties.Properties
+	data []csventry
+}
+
+func InitCSV(p *properties.Properties) *csv {
+	return &csv{
+		p: p,
+	}
+}
+
+func (c *csv) Info() map[string]ycsb.MeasurementInfo {
+	opMeasurementInfo := make(map[string]ycsb.MeasurementInfo)
+	return opMeasurementInfo
+}
+
+func (c *csv) Measure(op string, start time.Time, lan time.Duration) {
+	c.data = append(c.data, csventry{op, start, lan})
+}
+
+func (c *csv) Summary() map[string][]string {
+	summaries := make(map[string][]string)
+	return summaries
+}
+
+func (c *csv) OpNames() []string {
+	opNames := make([]string, 0)
+	return opNames
+}

--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
-	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/util"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
@@ -48,7 +47,7 @@ func (h *histogram) Info() ycsb.MeasurementInfo {
 	return newHistogramInfo(res)
 }
 
-func newHistogram(p *properties.Properties) *histogram {
+func newHistogram() *histogram {
 	h := new(histogram)
 	h.startTime = time.Now()
 	h.hist = hdrhistogram.New(1, 24*60*60*1000*1000, 3)

--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -19,7 +19,6 @@ import (
 
 	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/pingcap/go-ycsb/pkg/util"
-	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
 type histogram struct {
@@ -40,12 +39,6 @@ const (
 	PER999TH  = "PER999TH"
 	PER9999TH = "PER9999TH"
 )
-
-func (h *histogram) Info() ycsb.MeasurementInfo {
-	res := h.getInfo()
-	delete(res, ELAPSED)
-	return newHistogramInfo(res)
-}
 
 func newHistogram() *histogram {
 	h := new(histogram)
@@ -101,19 +94,4 @@ func (h *histogram) getInfo() map[string]interface{} {
 	res[PER9999TH] = per9999
 
 	return res
-}
-
-type histogramInfo struct {
-	info map[string]interface{}
-}
-
-func newHistogramInfo(info map[string]interface{}) *histogramInfo {
-	return &histogramInfo{info: info}
-}
-
-func (hi *histogramInfo) Get(metricName string) interface{} {
-	if value, ok := hi.info[metricName]; ok {
-		return value
-	}
-	return nil
 }

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -1,0 +1,55 @@
+package measurement
+
+import (
+	"time"
+
+	"github.com/magiconair/properties"
+	"github.com/pingcap/go-ycsb/pkg/ycsb"
+)
+
+type histograms struct {
+	p *properties.Properties
+
+	histograms map[string]*histogram
+}
+
+func (h *histograms) Measure(op string, start time.Time, lan time.Duration) {
+	opM, ok := h.histograms[op]
+	if !ok {
+		opM = newHistogram(h.p)
+		h.histograms[op] = opM
+	}
+
+	opM.Measure(lan)
+}
+
+func (h *histograms) Summary() map[string][]string {
+	summaries := make(map[string][]string, len(h.histograms))
+	for op, opM := range h.histograms {
+		summaries[op] = opM.Summary()
+	}
+	return summaries
+}
+
+func (h *histograms) Info() map[string]ycsb.MeasurementInfo {
+	opMeasurementInfo := make(map[string]ycsb.MeasurementInfo, len(h.histograms))
+	for op, opM := range h.histograms {
+		opMeasurementInfo[op] = opM.Info()
+	}
+	return opMeasurementInfo
+}
+
+func (h *histograms) OpNames() []string {
+	opNames := make([]string, 0, len(h.histograms))
+	for op := range h.histograms {
+		opNames = append(opNames, op)
+	}
+	return opNames
+}
+
+func InitHistograms(p *properties.Properties) *histograms {
+	return &histograms{
+		p:          p,
+		histograms: make(map[string]*histogram, 16),
+	}
+}

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -72,14 +72,6 @@ func (h *histograms) Info() map[string]ycsb.MeasurementInfo {
 	return opMeasurementInfo
 }
 
-func (h *histograms) OpNames() []string {
-	opNames := make([]string, 0, len(h.histograms))
-	for op := range h.histograms {
-		opNames = append(opNames, op)
-	}
-	return opNames
-}
-
 func InitHistograms(p *properties.Properties) *histograms {
 	return &histograms{
 		p:          p,

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -8,7 +8,6 @@ import (
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/prop"
 	"github.com/pingcap/go-ycsb/pkg/util"
-	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
 type histograms struct {
@@ -62,14 +61,6 @@ func (h *histograms) Output(w io.Writer) error {
 		panic("unsupported outputstyle: " + outputStyle)
 	}
 	return nil
-}
-
-func (h *histograms) Info() map[string]ycsb.MeasurementInfo {
-	opMeasurementInfo := make(map[string]ycsb.MeasurementInfo, len(h.histograms))
-	for op, opM := range h.histograms {
-		opMeasurementInfo[op] = opM.Info()
-	}
-	return opMeasurementInfo
 }
 
 func InitHistograms(p *properties.Properties) *histograms {

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -26,7 +26,7 @@ func (h *histograms) Measure(op string, start time.Time, lan time.Duration) {
 	opM.Measure(lan)
 }
 
-func (h *histograms) Summary() map[string][]string {
+func (h *histograms) summary() map[string][]string {
 	summaries := make(map[string][]string, len(h.histograms))
 	for op, opM := range h.histograms {
 		summaries[op] = opM.Summary()
@@ -35,7 +35,7 @@ func (h *histograms) Summary() map[string][]string {
 }
 
 func (h *histograms) Output(w io.Writer) error {
-	summaries := h.Summary()
+	summaries := h.summary()
 	keys := make([]string, 0, len(summaries))
 	for k := range summaries {
 		keys = append(keys, k)

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -2,6 +2,7 @@ package measurement
 
 import (
 	"io"
+	"os"
 	"sort"
 	"time"
 
@@ -32,6 +33,10 @@ func (h *histograms) summary() map[string][]string {
 		summaries[op] = opM.Summary()
 	}
 	return summaries
+}
+
+func (h *histograms) Summary() {
+	h.Output(os.Stdout)
 }
 
 func (h *histograms) Output(w io.Writer) error {

--- a/pkg/measurement/histograms.go
+++ b/pkg/measurement/histograms.go
@@ -20,7 +20,7 @@ type histograms struct {
 func (h *histograms) Measure(op string, start time.Time, lan time.Duration) {
 	opM, ok := h.histograms[op]
 	if !ok {
-		opM = newHistogram(h.p)
+		opM = newHistogram()
 		h.histograms[op] = opM
 	}
 

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -14,6 +14,7 @@
 package measurement
 
 import (
+	"io"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -44,7 +45,18 @@ func (m *measurement) output() {
 	m.RLock()
 	defer m.RUnlock()
 
-	w := os.Stdout
+	outFile := m.p.GetString(prop.MeasurementRawOutputFile, "")
+	var w io.Writer
+	if outFile == "" {
+		w = os.Stdout
+	} else {
+		f, err := os.Create(outFile)
+		if err != nil {
+			panic("failed to create output file: " + err.Error())
+		}
+		w = f
+	}
+
 	err := globalMeasure.measurer.Output(w)
 	if err != nil {
 		panic("failed to write output: " + err.Error())

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -14,7 +14,7 @@
 package measurement
 
 import (
-	"io"
+	"bufio"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -46,20 +46,25 @@ func (m *measurement) output() {
 	defer m.RUnlock()
 
 	outFile := m.p.GetString(prop.MeasurementRawOutputFile, "")
-	var w io.Writer
+	var w *bufio.Writer
 	if outFile == "" {
-		w = os.Stdout
+		w = bufio.NewWriter(os.Stdout)
 	} else {
 		f, err := os.Create(outFile)
 		if err != nil {
 			panic("failed to create output file: " + err.Error())
 		}
-		w = f
+		w = bufio.NewWriter(f)
 	}
 
 	err := globalMeasure.measurer.Output(w)
 	if err != nil {
 		panic("failed to write output: " + err.Error())
+	}
+
+	err = w.Flush()
+	if err != nil {
+		panic("failed to flush output: " + err.Error())
 	}
 }
 

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -47,10 +47,8 @@ func (m *measurement) output() {
 
 	summaries := m.opMeasurement.Summary()
 	keys := make([]string, 0, len(summaries))
-	var i = 0
 	for k := range summaries {
-		keys[i] = k
-		i += 1
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
@@ -92,7 +90,7 @@ func (m *measurement) getOpName() []string {
 func InitMeasure(p *properties.Properties) {
 	globalMeasure = new(measurement)
 	globalMeasure.p = p
-	measurementType := p.GetString(prop.MeasurementType, "")
+	measurementType := p.GetString(prop.MeasurementType, prop.MeasurementTypeDefault)
 	switch measurementType {
 	case "histogram":
 		globalMeasure.opMeasurement = InitHistograms(p)

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -96,6 +96,8 @@ func InitMeasure(p *properties.Properties) {
 	switch measurementType {
 	case "histogram":
 		globalMeasure.opMeasurement = InitHistograms(p)
+	case "raw":
+		globalMeasure.opMeasurement = InitCSV(p)
 	default:
 		panic("unsupported measurement type: " + measurementType)
 	}

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -94,7 +94,7 @@ func InitMeasure(p *properties.Properties) {
 	switch measurementType {
 	case "histogram":
 		globalMeasure.opMeasurement = InitHistograms(p)
-	case "raw":
+	case "raw", "csv":
 		globalMeasure.opMeasurement = InitCSV(p)
 	default:
 		panic("unsupported measurement type: " + measurementType)

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -92,7 +92,13 @@ func (m *measurement) getOpName() []string {
 func InitMeasure(p *properties.Properties) {
 	globalMeasure = new(measurement)
 	globalMeasure.p = p
-	globalMeasure.opMeasurement = InitHistograms(p)
+	measurementType := p.GetString(prop.MeasurementType, "")
+	switch measurementType {
+	case "histogram":
+		globalMeasure.opMeasurement = InitHistograms(p)
+	default:
+		panic("unsupported measurement type: " + measurementType)
+	}
 	EnableWarmUp(p.GetInt64(prop.WarmUpTime, 0) > 0)
 }
 

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -14,14 +14,13 @@
 package measurement
 
 import (
-	"sort"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/magiconair/properties"
 	"github.com/pingcap/go-ycsb/pkg/prop"
-	"github.com/pingcap/go-ycsb/pkg/util"
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
@@ -45,30 +44,10 @@ func (m *measurement) output() {
 	m.RLock()
 	defer m.RUnlock()
 
-	summaries := m.opMeasurement.Summary()
-	keys := make([]string, 0, len(summaries))
-	for k := range summaries {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	lines := [][]string{}
-	for _, op := range keys {
-		line := []string{op}
-		line = append(line, summaries[op]...)
-		lines = append(lines, line)
-	}
-
-	outputStyle := m.p.GetString(prop.OutputStyle, util.OutputStylePlain)
-	switch outputStyle {
-	case util.OutputStylePlain:
-		util.RenderString("%-6s - %s\n", header, lines)
-	case util.OutputStyleJson:
-		util.RenderJson(header, lines)
-	case util.OutputStyleTable:
-		util.RenderTable(header, lines)
-	default:
-		panic("unsupported outputstyle: " + outputStyle)
+	w := os.Stdout
+	err := globalMeasure.opMeasurement.Output(w)
+	if err != nil {
+		panic("failed to write output: " + err.Error())
 	}
 }
 

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -54,6 +54,7 @@ func (m *measurement) output() {
 		if err != nil {
 			panic("failed to create output file: " + err.Error())
 		}
+		defer f.Close()
 		w = bufio.NewWriter(f)
 	}
 

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -67,7 +67,7 @@ func InitMeasure(p *properties.Properties) {
 	case "histogram":
 		globalMeasure.opMeasurement = InitHistograms(p)
 	case "raw", "csv":
-		globalMeasure.opMeasurement = InitCSV(p)
+		globalMeasure.opMeasurement = InitCSV()
 	default:
 		panic("unsupported measurement type: " + measurementType)
 	}

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -51,13 +51,6 @@ func (m *measurement) output() {
 	}
 }
 
-func (m *measurement) info() map[string]ycsb.MeasurementInfo {
-	m.RLock()
-	defer m.RUnlock()
-
-	return m.opMeasurement.Info()
-}
-
 func (m *measurement) getOpName() []string {
 	m.RLock()
 	defer m.RUnlock()
@@ -105,12 +98,6 @@ func Measure(op string, start time.Time, lan time.Duration) {
 	if IsWarmUpFinished() {
 		globalMeasure.measure(op, start, lan)
 	}
-}
-
-// Info returns all the operations MeasurementInfo.
-// The key of returned map is the operation name.
-func Info() map[string]ycsb.MeasurementInfo {
-	return globalMeasure.info()
 }
 
 // GetOpNames returns a string slice which contains all the operation name measured.

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -68,6 +68,12 @@ func (m *measurement) output() {
 	}
 }
 
+func (m *measurement) summary() {
+	m.RLock()
+	globalMeasure.measurer.Summary()
+	m.RUnlock()
+}
+
 // InitMeasure initializes the global measurement.
 func InitMeasure(p *properties.Properties) {
 	globalMeasure = new(measurement)
@@ -84,9 +90,14 @@ func InitMeasure(p *properties.Properties) {
 	EnableWarmUp(p.GetInt64(prop.WarmUpTime, 0) > 0)
 }
 
-// Output prints the measurement summary.
+// Output prints the complete measurements.
 func Output() {
 	globalMeasure.output()
+}
+
+// Summary prints the measurement summary.
+func Summary() {
+	globalMeasure.summary()
 }
 
 // EnableWarmUp sets whether to enable warm-up.

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -111,7 +111,7 @@ const (
 
 	MeasurementType          = "measurementtype"
 	MeasurementTypeDefault   = "histogram"
-	MeasurementRawOutputFile = "measurement.raw.output_file"
+	MeasurementRawOutputFile = "measurement.output_file"
 
 	Command = "command"
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -110,6 +110,7 @@ const (
 	LogInterval = "measurement.interval"
 
 	MeasurementType          = "measurementtype"
+	MeasurementTypeDefault   = "histogram"
 	MeasurementRawOutputfile = "measurement.raw.output_file"
 
 	Command = "command"

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -111,7 +111,7 @@ const (
 
 	MeasurementType          = "measurementtype"
 	MeasurementTypeDefault   = "histogram"
-	MeasurementRawOutputfile = "measurement.raw.output_file"
+	MeasurementRawOutputFile = "measurement.raw.output_file"
 
 	Command = "command"
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -109,6 +109,9 @@ const (
 
 	LogInterval = "measurement.interval"
 
+	MeasurementType          = "measurementtype"
+	MeasurementRawOutputfile = "measurement.raw.output_file"
+
 	Command = "command"
 
 	OutputStyle = "outputstyle"

--- a/pkg/util/output.go
+++ b/pkg/util/output.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -18,7 +18,7 @@ const (
 )
 
 // RenderString renders headers and values according to the format provided
-func RenderString(format string, headers []string, values [][]string) {
+func RenderString(w io.Writer, format string, headers []string, values [][]string) {
 	if len(values) == 0 {
 		return
 	}
@@ -31,22 +31,22 @@ func RenderString(format string, headers []string, values [][]string) {
 		}
 		buf.WriteString(fmt.Sprintf(format, value[0], strings.Join(args, ", ")))
 	}
-	fmt.Print(buf.String())
+	fmt.Fprint(w, buf.String())
 }
 
 // RenderTable will use given headers and values to render a table style output
-func RenderTable(headers []string, values [][]string) {
+func RenderTable(w io.Writer, headers []string, values [][]string) {
 	if len(values) == 0 {
 		return
 	}
-	tb := tablewriter.NewWriter(os.Stdout)
+	tb := tablewriter.NewWriter(w)
 	tb.SetHeader(headers)
 	tb.AppendBulk(values)
 	tb.Render()
 }
 
 // RnederJson will combine the headers and values and print a json string
-func RenderJson(headers []string, values [][]string) {
+func RenderJson(w io.Writer, headers []string, values [][]string) {
 	if len(values) == 0 {
 		return
 	}
@@ -60,10 +60,10 @@ func RenderJson(headers []string, values [][]string) {
 	}
 	outStr, err := json.Marshal(data)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(w, err)
 		return
 	}
-	fmt.Println(string(outStr))
+	fmt.Fprintln(w, string(outStr))
 }
 
 // IntToString formats int value to string

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -444,7 +444,7 @@ func (c *core) doTransactionRead(ctx context.Context, db ycsb.DB, state *coreSta
 func (c *core) doTransactionReadModifyWrite(ctx context.Context, db ycsb.DB, state *coreState) error {
 	start := time.Now()
 	defer func() {
-		measurement.Measure("READ_MODIFY_WRITE", time.Now().Sub(start))
+		measurement.Measure("READ_MODIFY_WRITE", start, time.Now().Sub(start))
 	}()
 
 	r := state.r

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -25,6 +25,7 @@ type MeasurementInfo interface {
 	Get(metricName string) interface{}
 }
 
+// Measurer is used to capture measurements.
 type Measurer interface {
 	// Measure measures the latency of an operation.
 	Measure(op string, start time.Time, latency time.Duration)

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -18,13 +18,6 @@ import (
 	"time"
 )
 
-// MeasurementInfo contains metrics of one measurement.
-type MeasurementInfo interface {
-	// Get returns the value corresponded to the specified metric, such QPS, MIN, MAX，etc.
-	// If metric does not exist, the returned value will be nil.
-	Get(metricName string) interface{}
-}
-
 // Measurer is used to capture measurements.
 type Measurer interface {
 	// Measure measures the latency of an operation.

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -24,8 +24,18 @@ type MeasurementInfo interface {
 	Get(metricName string) interface{}
 }
 
-// Measurement measures the operations metrics.
 type Measurement interface {
+	Measure(op string, start time.Time, latency time.Duration)
+
+	Summary() map[string][]string
+
+	Info() map[string]MeasurementInfo
+
+	OpNames() []string
+}
+
+// OpMeasurement measures the operations metrics.
+type OpMeasurement interface {
 	// Measure measures the operation latency.
 	Measure(latency time.Duration)
 	// Summary returns the summary of the measurement.

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -23,6 +23,9 @@ type Measurer interface {
 	// Measure measures the latency of an operation.
 	Measure(op string, start time.Time, latency time.Duration)
 
+	// Summary writes a summary of the current measurement results to stdout.
+	Summary()
+
 	// Output writes the measurement results to the specified writer.
 	Output(w io.Writer) error
 }

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -25,20 +25,10 @@ type MeasurementInfo interface {
 	Get(metricName string) interface{}
 }
 
-type Measurement interface {
+type Measurer interface {
+	// Measure measures the latency of an operation.
 	Measure(op string, start time.Time, latency time.Duration)
 
+	// Output writes the measurement results to the specified writer.
 	Output(w io.Writer) error
-
-	OpNames() []string
-}
-
-// OpMeasurement measures the operations metrics.
-type OpMeasurement interface {
-	// Measure measures the operation latency.
-	Measure(latency time.Duration)
-	// Summary returns the summary of the measurement.
-	Summary() []string
-	// Info returns the MeasurementInfo of the measurement.
-	Info() MeasurementInfo
 }

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -28,8 +28,6 @@ type MeasurementInfo interface {
 type Measurement interface {
 	Measure(op string, start time.Time, latency time.Duration)
 
-	Info() map[string]MeasurementInfo
-
 	Output(w io.Writer) error
 
 	OpNames() []string

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -14,6 +14,7 @@
 package ycsb
 
 import (
+	"io"
 	"time"
 )
 
@@ -27,9 +28,9 @@ type MeasurementInfo interface {
 type Measurement interface {
 	Measure(op string, start time.Time, latency time.Duration)
 
-	Summary() map[string][]string
-
 	Info() map[string]MeasurementInfo
+
+	Output(w io.Writer) error
 
 	OpNames() []string
 }


### PR DESCRIPTION
- Record start time in measurements
- Adds the CSV measurement type
- Adds configurable writing to file for measurements
- Rework measurement reporting to be handled inside the measurement type (histograms output different structure to csv)
    - This removes the `Info` and `Summary` methods providing a simpler interface
- Add output configuration section to README

Fixes #255 