### PR TITLE
Fix compile error with rocksdb, foundationdb tags

### DIFF
--- a/db/foundationdb/db.go
+++ b/db/foundationdb/db.go
@@ -153,7 +153,7 @@ func (db *fDB) Update(ctx context.Context, table string, key string, values map[
 		buf := db.bufPool.Get()
 		defer db.bufPool.Put(buf)
 
-		buf, err := db.r.Encode(buf, data)
+		buf, err = db.r.Encode(buf, data)
 		if err != nil {
 			return nil, err
 		}

--- a/db/rocksdb/db.go
+++ b/db/rocksdb/db.go
@@ -232,7 +232,7 @@ func (db *rocksDB) Update(ctx context.Context, table string, key string, values 
 	buf := db.bufPool.Get()
 	defer db.bufPool.Put(buf)
 
-	buf, err := db.r.Encode(buf, m)
+	buf, err = db.r.Encode(buf, m)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #226

Fix the following error when building with `CGO_CXXFLAGS=" -std=c++11" go build -tags " foundationdb rocksdb" -o bin/go-ycsb cmd/go-ycsb/*`:
`no new variables on left side of :=` (buf, err are already initialized)