### PR TITLE
Added support of original java ycsb workload files

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -702,4 +702,5 @@ func (coreCreator) Create(p *properties.Properties) (ycsb.Workload, error) {
 
 func init() {
 	ycsb.RegisterWorkloadCreator("core", coreCreator{})
+	ycsb.RegisterWorkloadCreator("site.ycsb.workloads.CoreWorkload", coreCreator{})
 }


### PR DESCRIPTION
Java YCSB workloads contains line (see [original repo](https://github.com/brianfrankcooper/YCSB/blob/master/workloads/workloada#L27))
```
workload=site.ycsb.workloads.CoreWorkload
```
This line provokes panic in go-ycsb:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xab8cc8]

goroutine 1 [running]:
main.initialGlobal({0x7ffe905df708, 0x3}, 0xc00020faa0)
        /Users/asmyasnikov/ydb/go-ycsb/cmd/go-ycsb/main.go:92 +0x2c8
main.runClientCommandFunc(0x0?, {0xc000344240?, 0x0?, 0x0?}, 0x0?, {0xcbc5f9?, 0x0?})
        /Users/asmyasnikov/ydb/go-ycsb/cmd/go-ycsb/client.go:30 +0xaa
main.runTransCommandFunc(0xc00030e900?, {0xc000344240?, 0x11?, 0x12?})
        /Users/asmyasnikov/ydb/go-ycsb/cmd/go-ycsb/client.go:71 +0x30
github.com/spf13/cobra.(*Command).execute(0xc00030e900, {0xc000344120, 0x11, 0x12})
        /Users/asmyasnikov/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xc00030e000)
        /Users/asmyasnikov/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/asmyasnikov/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
        /Users/asmyasnikov/ydb/go-ycsb/cmd/go-ycsb/main.go:148 +0x22c
```

My PR fix this panic