### PR TITLE
Added capability of exporting per operation type full latency percentile output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ log
 vendor
 tool/tool
 .DS_Store
+
+# percentile output format
+*.txt
+
+# hdr-plot output format
+*.png

--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -58,7 +58,7 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 	c := client.NewClient(globalProps, globalWorkload, globalDB)
 	start := time.Now()
 	c.Run(globalContext)
-
+	fmt.Println("**********************************************")
 	fmt.Printf("Run finished, takes %s\n", time.Now().Sub(start))
 	measurement.Output()
 }

--- a/pkg/client/dbwrapper.go
+++ b/pkg/client/dbwrapper.go
@@ -35,6 +35,7 @@ func measure(start time.Time, op string, err error) {
 	}
 
 	measurement.Measure(op, start, lan)
+	measurement.Measure("TOTAL", start, lan)
 }
 
 func (db DbWrapper) Close() error {

--- a/pkg/measurement/csv.go
+++ b/pkg/measurement/csv.go
@@ -17,6 +17,9 @@ type csvs struct {
 	opCsv map[string][]csventry
 }
 
+func (c *csvs) GenerateExtendedOutputs() {
+}
+
 func InitCSV() *csvs {
 	return &csvs{
 		opCsv: make(map[string][]csventry),

--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -35,6 +35,9 @@ const (
 	AVG       = "AVG"
 	MIN       = "MIN"
 	MAX       = "MAX"
+	PER50TH   = "PER50TH"
+	PER90TH   = "PER90TH"
+	PER95TH   = "PER95TH"
 	PER99TH   = "PER99TH"
 	PER999TH  = "PER999TH"
 	PER9999TH = "PER9999TH"
@@ -61,6 +64,9 @@ func (h *histogram) Summary() []string {
 		util.IntToString(res[AVG]),
 		util.IntToString(res[MIN]),
 		util.IntToString(res[MAX]),
+		util.IntToString(res[PER50TH]),
+		util.IntToString(res[PER90TH]),
+		util.IntToString(res[PER95TH]),
 		util.IntToString(res[PER99TH]),
 		util.IntToString(res[PER999TH]),
 		util.IntToString(res[PER9999TH]),
@@ -76,6 +82,9 @@ func (h *histogram) getInfo() map[string]interface{} {
 	bounds := h.boundCounts.Keys()
 	sort.Ints(bounds)
 
+	per50 := h.hist.ValueAtPercentile(50)
+	per90 := h.hist.ValueAtPercentile(90)
+	per95 := h.hist.ValueAtPercentile(95)
 	per99 := h.hist.ValueAtPercentile(99)
 	per999 := h.hist.ValueAtPercentile(99.9)
 	per9999 := h.hist.ValueAtPercentile(99.99)
@@ -89,6 +98,9 @@ func (h *histogram) getInfo() map[string]interface{} {
 	res[AVG] = avg
 	res[MIN] = min
 	res[MAX] = max
+	res[PER50TH] = per50
+	res[PER90TH] = per90
+	res[PER95TH] = per95
 	res[PER99TH] = per99
 	res[PER999TH] = per999
 	res[PER9999TH] = per9999

--- a/pkg/measurement/measurement.go
+++ b/pkg/measurement/measurement.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/go-ycsb/pkg/ycsb"
 )
 
-var header = []string{"Operation", "Takes(s)", "Count", "OPS", "Avg(us)", "Min(us)", "Max(us)", "99th(us)", "99.9th(us)", "99.99th(us)"}
+var header = []string{"Operation", "Takes(s)", "Count", "OPS", "Avg(us)", "Min(us)", "Max(us)", "50th(us)", "90th(us)", "95th(us)", "99th(us)", "99.9th(us)", "99.99th(us)"}
 
 type measurement struct {
 	sync.RWMutex
@@ -93,6 +93,7 @@ func InitMeasure(p *properties.Properties) {
 
 // Output prints the complete measurements.
 func Output() {
+	globalMeasure.measurer.GenerateExtendedOutputs()
 	globalMeasure.output()
 }
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -116,4 +116,10 @@ const (
 	Command = "command"
 
 	OutputStyle = "outputstyle"
+
+	// MeasurementHistogramPercentileExport properties -- related to histogram latencies exporting
+	MeasurementHistogramPercentileExport                = "histogram.percentiles.export"
+	MeasurementHistogramPercentileExportDefault         = false
+	MeasurementHistogramPercentileExportFilepath        = "histogram.percentiles.export.filepath"
+	MeasurementHistogramPercentileExportFilepathDefault = "./"
 )

--- a/pkg/ycsb/measurement.go
+++ b/pkg/ycsb/measurement.go
@@ -26,6 +26,9 @@ type Measurer interface {
 	// Summary writes a summary of the current measurement results to stdout.
 	Summary()
 
+	// GenerateExtendedOutputs is called at the end of the benchmark
+	GenerateExtendedOutputs()
+
 	// Output writes the measurement results to the specified writer.
 	Output(w io.Writer) error
 }


### PR DESCRIPTION
The following PR enables exporting the full percentile latencies of each operation type, in the HdrHistogram standard output format, via the added properties `histogram.percentiles.export` (true or false) and `histogram.percentiles.export.filepath` (default = "./" which stores to current folder ).


Tools like https://hdrhistogram.github.io/HdrHistogram/plotFiles.html and https://github.com/BrunoBonacci/hdr-plot can be used to generate charts like the following one:

![image](https://user-images.githubusercontent.com/5832149/141475486-53625361-10d3-4a79-90d9-9a4e8383a6a3.png)

