### PR TITLE
Rnabling TLS connection in redis when solely redis.ca_cert is provided

### DIFF
--- a/db/redis/db.go
+++ b/db/redis/db.go
@@ -308,7 +308,7 @@ func parseTLS(p *properties.Properties) *tls.Config {
 	certPath, _ := p.Get(redisTLSCert)
 	keyPath, _ := p.Get(redisTLSKey)
 	insecureSkipVerify := p.GetBool(redisTLSInsecureSkipVerify, false)
-	if certPath != "" && keyPath != "" {
+	if (certPath != "" && keyPath != "") || (caPath != "") {
 		config, err := util.CreateTLSConfig(caPath, certPath, keyPath, insecureSkipVerify)
 		if err == nil {
 			return config


### PR DESCRIPTION
In the case where we only provide the ca_cert we can still connect securely to redis. This PR enables it. 