### PR TITLE
Fix opcount calculation

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -76,6 +76,9 @@ func newWorker(p *properties.Properties, threadID int, threadCount int, workload
 	}
 
 	w.opCount = totalOpCount / int64(threadCount)
+	if threadID < int(totalOpCount%int64(threadCount)) {
+		w.opCount++
+	}
 
 	targetPerThreadPerms := float64(-1)
 	if v := p.GetInt64(prop.Target, 0); v > 0 {


### PR DESCRIPTION
If the OpCount is not a multiple of threadCount, the sum will not match the totalOpCount.
For example, if I load 100 records with 3 threads, only 99 records will be loaded as each thread inserts 33 records.