### PR TITLE
Fixed artifact publishing GH action permissions.

### DIFF
--- a/.github/workflows/github-release-publish.yml
+++ b/.github/workflows/github-release-publish.yml
@@ -9,7 +9,12 @@ jobs:
   releases-matrix:
     name: Release Go Binary
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # To sign.
+      contents: write # To upload release assets.
+      actions: read   # To read workflow path.
     strategy:
+      fail-fast: false
       matrix:
         goos: [linux, darwin]
         goarch: [amd64, arm64]


### PR DESCRIPTION
- Disables fail fast -- so in the case of some of the artifacts fails it wont stop others from being uploaded
- Adds the required permissions to upload the artifacts

Confirmation that it's working as expected: 
https://github.com/redis-performance/go-ycsb/releases/tag/v0.0.7

Action run that published the artifacts: 
https://github.com/redis-performance/go-ycsb/actions/runs/4375337274
