### PR TITLE
pkg: support core workload minscanlength parameter

### DIFF
--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -71,6 +71,8 @@ const (
 	RequestDistributionDefault = "uniform"
 	ZeroPadding                = "zeropadding"
 	ZeroPaddingDefault         = int64(1)
+	MinScanLength              = "minscanlength"
+	MinScanLengthDefault       = int64(1)
 	MaxScanLength              = "maxscanlength"
 	MaxScanLengthDefault       = int64(1000)
 	// "uniform", "zipfian"

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -621,6 +621,7 @@ func (coreCreator) Create(p *properties.Properties) (ycsb.Workload, error) {
 	}
 
 	requestDistrib := p.GetString(prop.RequestDistribution, prop.RequestDistributionDefault)
+	minScanLength := p.GetInt64(prop.MinScanLength, prop.MinScanLengthDefault)
 	maxScanLength := p.GetInt64(prop.MaxScanLength, prop.MaxScanLengthDefault)
 	scanLengthDistrib := p.GetString(prop.ScanLengthDistribution, prop.ScanLengthDistributionDefault)
 
@@ -680,9 +681,9 @@ func (coreCreator) Create(p *properties.Properties) (ycsb.Workload, error) {
 	c.fieldChooser = generator.NewUniform(0, c.fieldCount-1)
 	switch scanLengthDistrib {
 	case "uniform":
-		c.scanLength = generator.NewUniform(1, maxScanLength)
+		c.scanLength = generator.NewUniform(minScanLength, maxScanLength)
 	case "zipfian":
-		c.scanLength = generator.NewZipfianWithRange(1, maxScanLength, generator.ZipfianConstant)
+		c.scanLength = generator.NewZipfianWithRange(minScanLength, maxScanLength, generator.ZipfianConstant)
 	default:
 		util.Fatalf("distribution %s not allowed for scan length", scanLengthDistrib)
 	}


### PR DESCRIPTION
https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties support the minscanlength paramter , and ther meaning is : for scans, what is the minimum number of records to scan (default: 1).