### PR TITLE
Add Prometheus metrics and hide sensitive info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-alpine3.16
+FROM golang:1.24.3-alpine3.21
 
 ENV GOPATH /go
 
@@ -6,7 +6,7 @@ RUN apk update && apk upgrade && \
     apk add --no-cache git build-base wget
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
- && chmod +x /usr/local/bin/dumb-init
+    && chmod +x /usr/local/bin/dumb-init
 
 RUN mkdir -p /go/src/github.com/pingcap/go-ycsb
 WORKDIR /go/src/github.com/pingcap/go-ycsb
@@ -20,7 +20,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /go-ycsb ./cmd/*
 
-FROM alpine:3.8 
+FROM alpine:3.21
 
 COPY --from=0 /go-ycsb /go-ycsb
 COPY --from=0 /usr/local/bin/dumb-init /usr/local/bin/dumb-init

--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/go-ycsb/pkg/client"
@@ -49,8 +50,22 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		}
 	})
 
+	// Prepare to hide sensitive information
+	sensitiveProperties := make([]string, 0)
+	if globalProps.GetString(prop.SensitiveProperties, "") != "" {
+		sensitiveProperties = strings.Split(globalProps.GetString(prop.SensitiveProperties, ""), ",")
+	}
+
 	fmt.Println("***************** properties *****************")
 	for key, value := range globalProps.Map() {
+		if len(sensitiveProperties) > 0 {
+			for _, sensitive := range sensitiveProperties {
+				if key == sensitive {
+					value = strings.Repeat("*", len(value))
+					break
+				}
+			}
+		}
 		fmt.Printf("\"%s\"=\"%s\"\n", key, value)
 	}
 	fmt.Println("**********************************************")

--- a/cmd/go-ycsb/main.go
+++ b/cmd/go-ycsb/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/magiconair/properties"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	// Register workload
 
@@ -113,6 +114,13 @@ func initialGlobal(dbName string, onProperties func()) {
 	addr := globalProps.GetString(prop.DebugPprof, prop.DebugPprofDefault)
 	go func() {
 		http.ListenAndServe(addr, nil)
+	}()
+
+	metricsAddr := globalProps.GetString(prop.MetricsAddr, prop.MetricsAddrDefault)
+	go func() {
+		fmt.Printf("Starting metrics server at %s\n", metricsAddr)
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(metricsAddr, nil)
 	}()
 
 	measurement.InitMeasure(globalProps)

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -124,4 +124,14 @@ const (
 	MeasurementHistogramPercentileExportDefault         = false
 	MeasurementHistogramPercentileExportFilepath        = "histogram.percentiles.export.filepath"
 	MeasurementHistogramPercentileExportFilepathDefault = "./"
+
+	// Prometheus metrics properties
+	MetricsAddr               = "metrics.address"
+	MetricsAddrDefault        = ":8765"
+	MetricsHistBuckets        = "metrics.histogram.buckets"
+	MetricsHistBucketsDefault = "1,10,100,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000,20000,30000,40000,50000,60000,70000,80000,90000,100000,1000000,10000000,100000000"
+
+	// Security
+	SensitiveProperties        = "sensitive_properties"
+	SensitivePropertiesDefault = "" // comma separated list of sensitive properties, for example: mysql.password,mysql.user
 )


### PR DESCRIPTION
- Add Prometheus histogram metric with configurable listen port and histogram buckets.
- Add new parameter "sensitive_properties" that allows to hide sensitive info from the output

      ***************** properties *****************
      "sensitive_properties"="mysql.password"
      "mysql.password"="**************"

- Update Go and Alpine images to 1.24.3 ad 3.21 respectively.