### PR TITLE
feat: decrease upper bound for histogram buckets

### DIFF
--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -46,7 +46,7 @@ const (
 func newHistogram() *histogram {
 	h := new(histogram)
 	h.startTime = time.Now()
-	h.hist = hdrhistogram.New(1, 24*60*60*1000*1000, 3)
+	h.hist = hdrhistogram.New(1, 60*60*1000*1000, 3) // define buckets from 1microsecond to 1hour with 0.1% uniform relative accuracy
 	return h
 }
 


### PR DESCRIPTION
YCSB metrics are measured and exported using defined buckets (here). These pre-defined buckets are too broad when we get over 100ms latency, which is the case for `pl-poz001` - the bucket boundary is (100ms, 1s). Hence, this PR increases the accuracy of the buckets around 100ms. This happens by decreasing the upper bound for histogram buckets in the `hdrhistogram.New()` call. 
 
 Ticket Ref.: https://app.clickup.com/t/24413607/PRODUCT-9976