### PR TITLE
feat: bucket histogram adjustment

### DIFF
--- a/.github/workflows/ic-build-image.yaml
+++ b/.github/workflows/ic-build-image.yaml
@@ -1,0 +1,59 @@
+name: Build IC Docker image
+
+on:
+  push:
+    branches: [ ic-build ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker image tag
+        id: img
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Check image tag
+        run: echo ${{ steps.img.outputs.sha_short }}
+
+      - name: Set docker image tag
+        id: generate-image-tag
+        run: echo "IMAGE_TAG=${{ steps.img.outputs.sha_short }}-$GITHUB_RUN_ATTEMPT" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-alpine3.16
+FROM golang:1.24.3-alpine3.21
 
 ENV GOPATH /go
 
@@ -6,7 +6,7 @@ RUN apk update && apk upgrade && \
     apk add --no-cache git build-base wget
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
- && chmod +x /usr/local/bin/dumb-init
+    && chmod +x /usr/local/bin/dumb-init
 
 RUN mkdir -p /go/src/github.com/pingcap/go-ycsb
 WORKDIR /go/src/github.com/pingcap/go-ycsb
@@ -20,7 +20,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /go-ycsb ./cmd/*
 
-FROM alpine:3.8 
+FROM alpine:3.21
 
 COPY --from=0 /go-ycsb /go-ycsb
 COPY --from=0 /usr/local/bin/dumb-init /usr/local/bin/dumb-init

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Impossiblecloud Fork Notification
+
+> [!WARNING]
+> !!! Default branch for all IC modifications is `ic-build` !!!
+> Please propose all PRs for `ic-build` branch, not `master`!
+
+Forked to add Prometheus metrics and make other adjustments we might need
+(for example GH actions to build the image, customization that do not make
+sense for the upstream, etc).
+
+All modifications must be made in `ic-build` branch. We keep `master` branch
+in sync with the upstream source, and then rebase our branch.
+
+Image is build automatically on merges into `ic-build` branch.
+
 # go-ycsb
 
 go-ycsb is a Go port of [YCSB](https://github.com/brianfrankcooper/YCSB). It fully supports all YCSB generators and the Core workload so we can do the basic CRUD benchmarks with Go.

--- a/cmd/go-ycsb/client.go
+++ b/cmd/go-ycsb/client.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/go-ycsb/pkg/client"
@@ -49,8 +50,22 @@ func runClientCommandFunc(cmd *cobra.Command, args []string, doTransactions bool
 		}
 	})
 
+	// Prepare to hide sensitive information
+	sensitiveProperties := make([]string, 0)
+	if globalProps.GetString(prop.SensitiveProperties, "") != "" {
+		sensitiveProperties = strings.Split(globalProps.GetString(prop.SensitiveProperties, ""), ",")
+	}
+
 	fmt.Println("***************** properties *****************")
 	for key, value := range globalProps.Map() {
+		if len(sensitiveProperties) > 0 {
+			for _, sensitive := range sensitiveProperties {
+				if key == sensitive {
+					value = strings.Repeat("*", len(value))
+					break
+				}
+			}
+		}
 		fmt.Printf("\"%s\"=\"%s\"\n", key, value)
 	}
 	fmt.Println("**********************************************")

--- a/cmd/go-ycsb/main.go
+++ b/cmd/go-ycsb/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/magiconair/properties"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	// Register workload
 
@@ -115,6 +116,13 @@ func initialGlobal(dbName string, onProperties func()) {
 	addr := globalProps.GetString(prop.DebugPprof, prop.DebugPprofDefault)
 	go func() {
 		http.ListenAndServe(addr, nil)
+	}()
+
+	metricsAddr := globalProps.GetString(prop.MetricsAddr, prop.MetricsAddrDefault)
+	go func() {
+		fmt.Printf("Starting metrics server at %s\n", metricsAddr)
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(metricsAddr, nil)
 	}()
 
 	measurement.InitMeasure(globalProps)

--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -46,7 +46,7 @@ const (
 func newHistogram() *histogram {
 	h := new(histogram)
 	h.startTime = time.Now()
-	h.hist = hdrhistogram.New(1, 24*60*60*1000*1000, 3)
+	h.hist = hdrhistogram.New(1, 60*60*1000*1000, 3) // define buckets from 1microsecond to 1hour with 0.1% uniform relative accuracy
 	return h
 }
 

--- a/pkg/measurement/histogram.go
+++ b/pkg/measurement/histogram.go
@@ -46,7 +46,7 @@ const (
 func newHistogram() *histogram {
 	h := new(histogram)
 	h.startTime = time.Now()
-	h.hist = hdrhistogram.New(1, 60*60*1000*1000, 3) // define buckets from 1microsecond to 1hour with 0.1% uniform relative accuracy
+	h.hist = hdrhistogram.New(1000, 60*60*1000*1000, 4) // define buckets from 1microsecond to 1hour with 0.1% uniform relative accuracy
 	return h
 }
 

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -124,4 +124,14 @@ const (
 	MeasurementHistogramPercentileExportDefault         = false
 	MeasurementHistogramPercentileExportFilepath        = "histogram.percentiles.export.filepath"
 	MeasurementHistogramPercentileExportFilepathDefault = "./"
+
+	// Prometheus metrics properties
+	MetricsAddr               = "metrics.address"
+	MetricsAddrDefault        = ":8765"
+	MetricsHistBuckets        = "metrics.histogram.buckets"
+	MetricsHistBucketsDefault = "1,10,100,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000,20000,30000,40000,50000,60000,70000,80000,90000,100000,1000000,10000000,100000000"
+
+	// Security
+	SensitiveProperties        = "sensitive_properties"
+	SensitivePropertiesDefault = "" // comma separated list of sensitive properties, for example: mysql.password,mysql.user
 )


### PR DESCRIPTION
The last adjustment (decreasing the max value from 24h to 1h) did not help, as it still maintains the same amount of buckets. Hence, increase the lowest value of the buckets from 1microsecond to 1ms and the accuracy from 3 to 4 (number of significant digits). 