### PR TITLE
Add support for using multiple S3 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Common configurations:
 |s3.use_path_style|false|Set `true` for LocalStack; forces path-style requests|
 |s3.update_overwrite|true|Set `false` for update to perform a read-modify-write operation|
 |s3.scan_keys_only|false|Set `true` to have scan return only the keys of the objects|
+ |s3.client_pool_size|1|The number of S3 clients to create for the benchmark, these will be distributed evenly across the threads|
 
 ## TODO
 


### PR DESCRIPTION
Add support for multiple S3 clients. The s3 clients are distributed among benchmarking threads evenly. For example, if there are 8 benchmarking threads and 2 clients, 4 threads will use 1 client. 