### PR TITLE
workload: don't return not-yet-inserted keys from nextKeyNum

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -408,7 +408,16 @@ func (c *core) nextKeyNum(state *coreState) int64 {
 			keyNum = c.transactionInsertKeySequence.Last() - c.keyChooser.Next(r)
 		}
 	} else {
+		// The zipfian chooser's range is extended by the expected number of
+		// run-phase inserts (see expectedNewKeys) so that the scrambled
+		// mapping of popular keys stays stable while the keyspace grows.
+		// Keys in the extension only exist once actually inserted, so redraw
+		// until the chosen key is within the acknowledged range. Mirrors the
+		// guard in upstream YCSB CoreWorkload.nextKeynum.
 		keyNum = c.keyChooser.Next(r)
+		for keyNum > c.transactionInsertKeySequence.Last() {
+			keyNum = c.keyChooser.Next(r)
+		}
 	}
 	return keyNum
 }

--- a/pkg/workload/core_guard_test.go
+++ b/pkg/workload/core_guard_test.go
@@ -1,0 +1,47 @@
+package workload
+
+import (
+	"context"
+	"testing"
+
+	"github.com/magiconair/properties"
+	"github.com/pingcap/go-ycsb/pkg/prop"
+)
+
+// The zipfian key chooser's range is extended beyond the loaded records by
+// the expected number of run-phase inserts (expectedNewKeys). nextKeyNum
+// must not return key numbers from the extension before they are actually
+// inserted and acknowledged; otherwise reads and updates target keys that
+// were never inserted. Mirrors the guard in upstream YCSB
+// CoreWorkload.nextKeynum.
+func TestZipfianNextKeyNumStaysWithinAcknowledgedRange(t *testing.T) {
+	p := properties.NewProperties()
+	p.Set(prop.RecordCount, "1000")
+	p.Set(prop.OperationCount, "10000")
+	p.Set(prop.RequestDistribution, "zipfian")
+	p.Set(prop.ReadProportion, "0.5")
+	p.Set(prop.UpdateProportion, "0")
+	p.Set(prop.ScanProportion, "0")
+	p.Set(prop.InsertProportion, "0.5")
+
+	wl, err := coreCreator{}.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := wl.(*core)
+	ctx := c.InitThread(context.Background(), 0, 1)
+	state := ctx.Value(stateKey).(*coreState)
+
+	last := c.transactionInsertKeySequence.Last()
+	violations := 0
+	const draws = 200000
+	for i := 0; i < draws; i++ {
+		if kn := c.nextKeyNum(state); kn > last {
+			violations++
+		}
+	}
+	if violations > 0 {
+		t.Fatalf("nextKeyNum returned a not-yet-inserted key %d/%d times (acknowledged Last=%d)",
+			violations, draws, last)
+	}
+}


### PR DESCRIPTION
## Problem

With `requestdistribution=zipfian` and a non-zero insert proportion, `nextKeyNum` can return key numbers that have never been inserted.

The zipfian branch intentionally extends the key chooser's range past the loaded records by `expectedNewKeys = operationcount * insertproportion * 2`, so that the scrambled zipfian's hot-key mapping stays stable while run-phase inserts grow the keyspace. Upstream Java YCSB pairs this extension with a guard in `CoreWorkload.nextKeynum()`:

```java
do {
  keynum = keychooser.nextValue().intValue();
} while (keynum > transactioninsertkeysequence.lastValue());
```

That guard was not ported, so any draw landing in the extension targets a key that does not exist yet.

The effect is large: with `recordcount=1000`, `operationcount=10000`, `insertproportion=0.5`, the extended range is [0, 11000) while only 1000 keys exist at the start of the run — about 91% of draws (182,945 out of 200,000 in the added test) point at not-yet-inserted keys.

## Impact

- Backends that report a missing key as an error see a flood of spurious read/update failures under zipfian.
- Backends that return `(nil, nil)` for a missing key (e.g. the TiKV drivers) count these as successful reads, which silently skews throughput/latency numbers — reading a non-existent key is cheaper than a real read.

## Fix

Port the upstream guard: redraw while the chosen key number is above the acknowledged insert counter. Newly inserted keys become readable as soon as they are acknowledged — exactly what the keyspace extension was designed for.

The loop is a no-op for the other distributions: uniform/sequential/hotspot choosers are bounded by the loaded records, `latest` follows the insert counter, and `exponential` already has its own handling.

## Test

`TestZipfianNextKeyNumStaysWithinAcknowledgedRange` fails before the fix (182,945/200,000 violations) and passes after.
