### PR TITLE
Fix DoInsert's retry condition, inverted by a prior commit

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -272,7 +272,7 @@ func (c *core) DoInsert(ctx context.Context, db ycsb.DB) error {
 	var err error
 	for {
 		err = db.Insert(ctx, c.table, dbKey, values)
-		if err != nil {
+		if err == nil {
 			break
 		}
 
@@ -610,6 +610,9 @@ func (coreCreator) Create(p *properties.Properties) (ycsb.Workload, error) {
 	c.p = p
 	c.table = p.GetString(prop.TableName, prop.TableNameDefault)
 	c.fieldCount = p.GetInt64(prop.FieldCount, prop.FieldCountDefault)
+	if c.fieldCount <= 0 {
+		util.Fatalf("%s must be > 0, got %d", prop.FieldCount, c.fieldCount)
+	}
 	c.fieldNames = make([]string, c.fieldCount)
 	for i := int64(0); i < c.fieldCount; i++ {
 		c.fieldNames[i] = fmt.Sprintf("field%d", i)


### PR DESCRIPTION
## Summary

- `DoInsert`'s retry loop breaks on `err != nil` instead of `err == nil`: a failed insert gives up immediately (`core_workload_insertion_retry_limit`/`core_workload_insertion_retry_interval` never actually retry a failure), while a *successful* insert loops back and redundantly re-sends itself up to the configured retry limit.
- `core_workload_insertion_retry_limit` is the documented way to harden a Load run against transient errors; with the inverted condition it does nothing for real failures, while every successful insert against a non-idempotent backend (e.g. one that errors on a duplicate key) gets pointlessly retried.
- Also rejects `fieldcount<=0` at `Create()` time with a clear error instead of panicking later inside `math/rand`'s `Int63n` the first time the field-chooser generator is used.

Found and verified while building a feature-store benchmark workload on top of this codebase (separate PR).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/workload/...` (pre-existing `open workloads/workloadc` test failure is unrelated - reproduces identically on unmodified `master`, it's a working-directory assumption in the test, not something this change touches)