### PR TITLE
Add a feature-store workload: typed field values, field naming, Redis HGETALL fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ Available Commands:
 ./bin/go-ycsb run basic -P workloads/workloada
 ```
 
+### Feature-store workload
+
+`workloads/workload_feature_store` models the entity-major serving layout from the [redis-benchmarks-specification feature-store playbook](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features-template.yml): one hash/document per entity (`feature_1`..`feature_50` + a trailing `event_ts` field), whole-entity reads (Redis `HGETALL`, MongoDB `findOne`), whole-row writes (`HSET`/`$set` of every field), a 95:5 read:write mix, and Zipfian-skewed serving traffic. Field values default to realistic typed scalars (numeric mix + a real timestamp) shaped like what [Feast](https://docs.feast.dev/reference/type-system) and [Featureform](https://docs.featureform.com/abstractions/feature) actually store, rather than opaque bytes. It works against `redis` and `mongodb` out of the box:
+
+```bash
+./bin/go-ycsb load redis   -P workloads/workload_feature_store -p redis.addr=127.0.0.1:6379
+./bin/go-ycsb run  redis   -P workloads/workload_feature_store -p redis.addr=127.0.0.1:6379
+
+./bin/go-ycsb load mongodb -P workloads/workload_feature_store -p mongodb.url="mongodb://127.0.0.1:27017/ycsb"
+./bin/go-ycsb run  mongodb -P workloads/workload_feature_store -p mongodb.url="mongodb://127.0.0.1:27017/ycsb"
+```
+
+See the comments at the top of `workloads/workload_feature_store` for the full data-shape/command-mix rationale, and the "Field generation" table below for the properties it's built from (`fieldnameprefix`, `fieldvaluetype`, etc.) - those are generic core-workload properties, so they work in any workload file, not just this one.
+
 ## Supported Database
 
 - MySQL / TiDB
@@ -101,6 +115,24 @@ Available Commands:
 - etcd
 - DynamoDB
 - S3 (Amazon S3 / S3-compatible)
+
+## Field generation
+
+These are core-workload properties (see [Running-a-Workload](https://github.com/brianfrankcooper/YCSB/wiki/Running-a-Workload) for the base set like `fieldcount`/`fieldlength`/`readallfields`); the ones below extend field naming and value content and work in any workload file.
+
+|field|default value|description|
+|-|-|-|
+|fieldlengthminimum|1|Lower bound for `uniform`/`zipfian` fieldlengthdistribution, e.g. to model 8-24 byte values instead of always starting at 1 byte|
+|fieldnameprefix|"field"|Prefix for generated field names (`field0`, `field1`, ...), e.g. `feature_` for `feature_0`, `feature_1`, ...|
+|fieldnamestartindex|0|Starting index for numbered field names, e.g. `1` for `feature_1`..`feature_N` instead of `feature_0`..`feature_(N-1)`|
+|lastfieldname|""|If set, overrides the name of the final generated field - e.g. a trailing `event_ts` metadata column alongside numbered feature fields|
+|fieldvaluetype|"random"|Content of generated field values: `random` (opaque bytes, only size matters), `integer`, `float`, `boolean`, `timestamp` (RFC3339), or `numeric` (a realistic int/float/boolean mix) - see [Feast](https://docs.feast.dev/reference/type-system)/[Featureform](https://docs.featureform.com/abstractions/feature)'s typed scalar columns for the shape this models|
+|lastfieldvaluetype|""|If set, overrides the value type of the final field (see `lastfieldname`), e.g. `timestamp` for a trailing `event_ts` field while numbered feature fields stay `numeric`. Must be set together with `lastfieldname`|
+|fieldvalueintegermin|0|Lower bound for `integer`/`numeric` fieldvaluetype content|
+|fieldvalueintegermax|100000|Upper bound for `integer`/`numeric` fieldvaluetype content, e.g. a bounded count column|
+|fieldvaluefloatmin|0.0|Lower bound for `float`/`numeric` fieldvaluetype content|
+|fieldvaluefloatmax|1.0|Upper bound for `float`/`numeric` fieldvaluetype content, e.g. a rate/score/probability column|
+|fieldvaluefloatprecision|4|Decimal places for `float`/`numeric` fieldvaluetype content, e.g. `0.8472`|
 
 ## Output configuration
 

--- a/db/redis/db.go
+++ b/db/redis/db.go
@@ -25,6 +25,7 @@ const HMGET string = "HMGET"
 
 type redisClient interface {
 	Get(ctx context.Context, key string) *goredis.StringCmd
+	HGetAll(ctx context.Context, key string) *goredis.MapStringStringCmd
 	Do(ctx context.Context, args ...interface{}) *goredis.Cmd
 	Pipeline() goredis.Pipeliner
 	Scan(ctx context.Context, cursor uint64, match string, count int64) *goredis.ScanCmd
@@ -75,6 +76,29 @@ func (r *redis) Read(ctx context.Context, table string, key string, fields []str
 			data[fieldName] = []byte(s)
 		}
 	case HASH_DATATYPE:
+		// Whole-entity read: nil/empty fields, or the full field set, maps to
+		// HGETALL rather than an HMGET enumerating every field. This matches
+		// how a feature-store style entity-major hash is served in production
+		// and lets Redis walk the hash directly instead of parsing a field list.
+		if len(fields) == 0 || int64(len(fields)) == r.fieldcount {
+			mapReply, errI := r.client.HGetAll(ctx, getKeyName(table, key)).Result()
+			if errI != nil {
+				err = errI
+				return
+			}
+			// Redis never stores a hash with zero fields (deleting the last
+			// field deletes the key), so an empty reply unambiguously means
+			// the key doesn't exist - surface that as an error rather than a
+			// silent empty-but-successful read, matching the HMGET path below.
+			if len(mapReply) == 0 {
+				err = fmt.Errorf("redis: no such key %q", getKeyName(table, key))
+				return
+			}
+			for fieldName, value := range mapReply {
+				data[fieldName] = []byte(value)
+			}
+			return
+		}
 		args := make([]interface{}, 0, len(fields)+2)
 		args = append(args, HMGET, getKeyName(table, key))
 		for _, fieldName := range fields {

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -47,13 +47,63 @@ const (
 	FieldLengthDistributionDefault = "constant"
 	FieldLength                    = "fieldlength"
 	FieldLengthDefault             = int64(100)
+	// Lower bound for "uniform"/"zipfian" fieldlengthdistribution. Lets a
+	// workload model field sizes that vary within a range (e.g. 8-24 bytes)
+	// instead of always starting at 1 byte.
+	FieldLengthMinimum        = "fieldlengthminimum"
+	FieldLengthMinimumDefault = int64(1)
 	// Used if fieldlengthdistribution is "histogram"
-	FieldLengthHistogramFile         = "fieldlengthhistogram"
-	FieldLengthHistogramFileDefault  = "hist.txt"
-	ReadAllFields                    = "readallfields"
-	ReadALlFieldsDefault             = true
-	WriteAllFields                   = "writeallfields"
-	WriteAllFieldsDefault            = false
+	FieldLengthHistogramFile        = "fieldlengthhistogram"
+	FieldLengthHistogramFileDefault = "hist.txt"
+	ReadAllFields                   = "readallfields"
+	ReadALlFieldsDefault            = true
+	WriteAllFields                  = "writeallfields"
+	WriteAllFieldsDefault           = false
+	// FieldNamePrefix/FieldNameStartIndex control how the generated field
+	// names (field0, field1, ...) are built, e.g. fieldnameprefix=feature_
+	// fieldnamestartindex=1 produces feature_1..feature_N.
+	FieldNamePrefix            = "fieldnameprefix"
+	FieldNamePrefixDefault     = "field"
+	FieldNameStartIndex        = "fieldnamestartindex"
+	FieldNameStartIndexDefault = int64(0)
+	// LastFieldName, if set, overrides the name of the final generated field.
+	// Useful for modeling a trailing metadata column alongside numbered
+	// feature fields, e.g. lastfieldname=event_ts.
+	LastFieldName        = "lastfieldname"
+	LastFieldNameDefault = ""
+	// FieldValueType controls the CONTENT of generated field values, not
+	// just their size. Feature-store fields are typically typed scalars
+	// (Feast: INT32/INT64/FLOAT32/FLOAT64/BOOL/STRING/UNIX_TIMESTAMP;
+	// Featureform: Int/Int32/Int64/Float32/Float64/Bool/String/Timestamp)
+	// rather than opaque bytes, so a workload can opt into realistic typed
+	// content instead of the default random-byte payload.
+	// One of: "random" (default, opaque random bytes), "numeric" (a mix of
+	// integer/float/boolean scalars), "integer", "float", "boolean",
+	// "timestamp" (RFC3339, e.g. for an event-time metadata field).
+	FieldValueType        = "fieldvaluetype"
+	FieldValueTypeDefault = "random"
+	// LastFieldValueType, if set, overrides the value type of the final
+	// generated field (see LastFieldName), e.g. lastfieldvaluetype=timestamp
+	// to give a trailing event_ts field realistic RFC3339 content while
+	// numbered feature fields stay numeric.
+	LastFieldValueType        = "lastfieldvaluetype"
+	LastFieldValueTypeDefault = ""
+	// Magnitude/precision for "integer" and "float" fieldvaluetype content.
+	// Defaults model the shape of typical feature-store scalars - e.g.
+	// Feast's driver-ranking demo features conv_rate/acc_rate (floats in
+	// [0,1)) and avg_daily_trips (a small bounded count) - rather than
+	// digit-filling to a target byte length.
+	FieldValueIntegerMin        = "fieldvalueintegermin"
+	FieldValueIntegerMinDefault = int64(0)
+	FieldValueIntegerMax        = "fieldvalueintegermax"
+	FieldValueIntegerMaxDefault = int64(100000)
+	FieldValueFloatMin          = "fieldvaluefloatmin"
+	FieldValueFloatMinDefault   = float64(0.0)
+	FieldValueFloatMax          = "fieldvaluefloatmax"
+	FieldValueFloatMaxDefault   = float64(1.0)
+	// Decimal places for "float" fieldvaluetype content, e.g. "0.8472".
+	FieldValueFloatPrecision         = "fieldvaluefloatprecision"
+	FieldValueFloatPrecisionDefault  = int64(4)
 	DataIntegrity                    = "dataintegrity"
 	DataIntegrityDefault             = false
 	ReadProportion                   = "readproportion"

--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -52,15 +52,33 @@ const (
 	readModifyWrite
 )
 
+// Field value content types (prop.FieldValueType / prop.LastFieldValueType).
+const (
+	fieldValueTypeRandom    = "random"
+	fieldValueTypeNumeric   = "numeric"
+	fieldValueTypeInteger   = "integer"
+	fieldValueTypeFloat     = "float"
+	fieldValueTypeBoolean   = "boolean"
+	fieldValueTypeTimestamp = "timestamp"
+)
+
 // Core is the core benchmark scenario. Represents a set of clients doing simple CRUD operations.
 type core struct {
 	p *properties.Properties
 
-	table      string
-	fieldCount int64
-	fieldNames []string
+	table         string
+	fieldCount    int64
+	fieldNames    []string
+	lastFieldName string
 
 	fieldLengthGenerator ycsb.Generator
+	fieldValueType       string
+	lastFieldValueType   string
+	fieldValueIntegerMin int64
+	fieldValueIntegerMax int64
+	fieldValueFloatMin   float64
+	fieldValueFloatMax   float64
+	fieldValueFloatPrec  int64
 	readAllFields        bool
 	writeAllFields       bool
 	dataIntegrity        bool
@@ -84,15 +102,16 @@ func getFieldLengthGenerator(p *properties.Properties) ycsb.Generator {
 	var fieldLengthGenerator ycsb.Generator
 	fieldLengthDistribution := p.GetString(prop.FieldLengthDistribution, prop.FieldLengthDistributionDefault)
 	fieldLength := p.GetInt64(prop.FieldLength, prop.FieldLengthDefault)
+	fieldLengthMinimum := p.GetInt64(prop.FieldLengthMinimum, prop.FieldLengthMinimumDefault)
 	fieldLengthHistogram := p.GetString(prop.FieldLengthHistogramFile, prop.FieldLengthHistogramFileDefault)
 
 	switch strings.ToLower(fieldLengthDistribution) {
 	case "constant":
 		fieldLengthGenerator = generator.NewConstant(fieldLength)
 	case "uniform":
-		fieldLengthGenerator = generator.NewUniform(1, fieldLength)
+		fieldLengthGenerator = generator.NewUniform(fieldLengthMinimum, fieldLength)
 	case "zipfian":
-		fieldLengthGenerator = generator.NewZipfianWithRange(1, fieldLength, generator.ZipfianConstant)
+		fieldLengthGenerator = generator.NewZipfianWithRange(fieldLengthMinimum, fieldLength, generator.ZipfianConstant)
 	case "histogram":
 		fieldLengthGenerator = generator.NewHistogramFromFile(fieldLengthHistogram)
 	default:
@@ -179,7 +198,7 @@ func (c *core) buildSingleValue(state *coreState, key string) map[string][]byte 
 	if c.dataIntegrity {
 		buf = c.buildDeterministicValue(state, key, fieldKey)
 	} else {
-		buf = c.buildRandomValue(state)
+		buf = c.buildFieldValue(state, fieldKey)
 	}
 
 	values[fieldKey] = buf
@@ -195,7 +214,7 @@ func (c *core) buildValues(state *coreState, key string) map[string][]byte {
 		if c.dataIntegrity {
 			buf = c.buildDeterministicValue(state, key, fieldKey)
 		} else {
-			buf = c.buildRandomValue(state)
+			buf = c.buildFieldValue(state, fieldKey)
 		}
 
 		values[fieldKey] = buf
@@ -209,6 +228,9 @@ func (c *core) getValueBuffer(size int) []byte {
 		return buf[0:size]
 	}
 
+	// If pooled buffer is too small, put it back and allocate a new one
+	// The new larger buffer will be returned to the pool later
+	c.valuePool.Put(buf)
 	return make([]byte, size)
 }
 
@@ -224,6 +246,85 @@ func (c *core) buildRandomValue(state *coreState) []byte {
 	buf := c.getValueBuffer(int(c.fieldLengthGenerator.Next(r)))
 	util.RandBytes(r, buf)
 	return buf
+}
+
+// buildFieldValue generates a field's content according to fieldValueType
+// (or lastFieldValueType, for the trailing lastFieldName field), letting a
+// workload model realistic typed scalars - as feature stores such as Feast
+// (INT32/INT64/FLOAT32/FLOAT64/BOOL/STRING/UNIX_TIMESTAMP) and Featureform
+// (Int/Float/Bool/String/Timestamp) do - instead of opaque random bytes.
+func (c *core) buildFieldValue(state *coreState, fieldKey string) []byte {
+	valueType := c.fieldValueType
+	if c.lastFieldValueType != "" && fieldKey == c.lastFieldName {
+		valueType = c.lastFieldValueType
+	}
+
+	switch valueType {
+	case fieldValueTypeInteger:
+		return c.buildIntegerValue(state)
+	case fieldValueTypeFloat:
+		return c.buildFloatValue(state)
+	case fieldValueTypeBoolean:
+		return c.buildBooleanValue(state)
+	case fieldValueTypeTimestamp:
+		return c.buildTimestampValue(state)
+	case fieldValueTypeNumeric:
+		// A realistic mix of the scalar kinds a feature store actually
+		// serves: mostly numeric (float/int), occasionally boolean.
+		switch state.r.Intn(10) {
+		case 0, 1:
+			return c.buildBooleanValue(state)
+		case 2, 3, 4, 5:
+			return c.buildFloatValue(state)
+		default:
+			return c.buildIntegerValue(state)
+		}
+	default:
+		return c.buildRandomValue(state)
+	}
+}
+
+// buildIntegerValue generates a decimal integer sampled uniformly from
+// [fieldValueIntegerMin, fieldValueIntegerMax] - the shape of a typical
+// feature-store count column (e.g. Feast's avg_daily_trips) - rather than
+// digit-filling to a target byte length.
+func (c *core) buildIntegerValue(state *coreState) []byte {
+	r := state.r
+	n := c.fieldValueIntegerMin + r.Int63n(c.fieldValueIntegerMax-c.fieldValueIntegerMin+1)
+	s := strconv.FormatInt(n, 10)
+	buf := c.getValueBuffer(len(s))
+	copy(buf, s)
+	return buf
+}
+
+// buildFloatValue generates a decimal float sampled uniformly from
+// [fieldValueFloatMin, fieldValueFloatMax) at fieldValueFloatPrec decimal
+// places, e.g. "0.8472" for the default [0,1) range - the shape of a typical
+// feature-store rate/score/probability column.
+func (c *core) buildFloatValue(state *coreState) []byte {
+	r := state.r
+	v := c.fieldValueFloatMin + r.Float64()*(c.fieldValueFloatMax-c.fieldValueFloatMin)
+	s := strconv.FormatFloat(v, 'f', int(c.fieldValueFloatPrec), 64)
+	buf := c.getValueBuffer(len(s))
+	copy(buf, s)
+	return buf
+}
+
+// buildBooleanValue returns the canonical "true"/"false" string a feature
+// store serializes a boolean feature as; fieldLengthGenerator does not apply
+// since a boolean has a fixed textual representation.
+func (c *core) buildBooleanValue(state *coreState) []byte {
+	if state.r.Intn(2) == 0 {
+		return []byte("true")
+	}
+	return []byte("false")
+}
+
+// buildTimestampValue returns an RFC3339 timestamp (e.g. for an event_ts
+// metadata field), sampled within the last 30 days.
+func (c *core) buildTimestampValue(state *coreState) []byte {
+	offset := time.Duration(state.r.Int63n(int64(30 * 24 * time.Hour)))
+	return []byte(time.Now().Add(-offset).UTC().Format(time.RFC3339))
 }
 
 func (c *core) buildDeterministicValue(state *coreState, key string, fieldKey string) []byte {
@@ -610,9 +711,48 @@ func (coreCreator) Create(p *properties.Properties) (ycsb.Workload, error) {
 	c.p = p
 	c.table = p.GetString(prop.TableName, prop.TableNameDefault)
 	c.fieldCount = p.GetInt64(prop.FieldCount, prop.FieldCountDefault)
+	fieldNamePrefix := p.GetString(prop.FieldNamePrefix, prop.FieldNamePrefixDefault)
+	fieldNameStartIndex := p.GetInt64(prop.FieldNameStartIndex, prop.FieldNameStartIndexDefault)
+	lastFieldName := p.GetString(prop.LastFieldName, prop.LastFieldNameDefault)
 	c.fieldNames = make([]string, c.fieldCount)
 	for i := int64(0); i < c.fieldCount; i++ {
-		c.fieldNames[i] = fmt.Sprintf("field%d", i)
+		c.fieldNames[i] = fmt.Sprintf("%s%d", fieldNamePrefix, fieldNameStartIndex+i)
+	}
+	if lastFieldName != "" && c.fieldCount > 0 {
+		c.fieldNames[c.fieldCount-1] = lastFieldName
+	}
+	c.lastFieldName = lastFieldName
+	c.fieldValueType = p.GetString(prop.FieldValueType, prop.FieldValueTypeDefault)
+	c.lastFieldValueType = p.GetString(prop.LastFieldValueType, prop.LastFieldValueTypeDefault)
+	c.fieldValueIntegerMin = p.GetInt64(prop.FieldValueIntegerMin, prop.FieldValueIntegerMinDefault)
+	c.fieldValueIntegerMax = p.GetInt64(prop.FieldValueIntegerMax, prop.FieldValueIntegerMaxDefault)
+	c.fieldValueFloatMin = p.GetFloat64(prop.FieldValueFloatMin, prop.FieldValueFloatMinDefault)
+	c.fieldValueFloatMax = p.GetFloat64(prop.FieldValueFloatMax, prop.FieldValueFloatMaxDefault)
+	c.fieldValueFloatPrec = p.GetInt64(prop.FieldValueFloatPrecision, prop.FieldValueFloatPrecisionDefault)
+	if c.fieldValueIntegerMax < c.fieldValueIntegerMin {
+		util.Fatalf("%s (%d) must be >= %s (%d)", prop.FieldValueIntegerMax, c.fieldValueIntegerMax, prop.FieldValueIntegerMin, c.fieldValueIntegerMin)
+	}
+	// diff<0 (wrapped) or diff==MaxInt64 (diff+1 would wrap) both mean the
+	// span doesn't fit the int64 range Int63n needs; either panics at value
+	// generation time instead of failing cleanly here.
+	if diff := c.fieldValueIntegerMax - c.fieldValueIntegerMin; diff < 0 || diff == math.MaxInt64 {
+		util.Fatalf("%s..%s span is too large to fit in an int64", prop.FieldValueIntegerMin, prop.FieldValueIntegerMax)
+	}
+	if c.fieldValueFloatMax < c.fieldValueFloatMin {
+		util.Fatalf("%s (%v) must be >= %s (%v)", prop.FieldValueFloatMax, c.fieldValueFloatMax, prop.FieldValueFloatMin, c.fieldValueFloatMin)
+	}
+	switch c.fieldValueType {
+	case fieldValueTypeRandom, fieldValueTypeNumeric, fieldValueTypeInteger, fieldValueTypeFloat, fieldValueTypeBoolean, fieldValueTypeTimestamp:
+	default:
+		util.Fatalf("unknown %s %q: expected random, numeric, integer, float, boolean, or timestamp", prop.FieldValueType, c.fieldValueType)
+	}
+	switch c.lastFieldValueType {
+	case "", fieldValueTypeRandom, fieldValueTypeNumeric, fieldValueTypeInteger, fieldValueTypeFloat, fieldValueTypeBoolean, fieldValueTypeTimestamp:
+	default:
+		util.Fatalf("unknown %s %q: expected random, numeric, integer, float, boolean, or timestamp", prop.LastFieldValueType, c.lastFieldValueType)
+	}
+	if c.lastFieldValueType != "" && c.lastFieldName == "" {
+		util.Fatalf("%s is set but %s is not - it has no field to apply to", prop.LastFieldValueType, prop.LastFieldName)
 	}
 	c.fieldLengthGenerator = getFieldLengthGenerator(p)
 	c.recordCount = p.GetInt64(prop.RecordCount, prop.RecordCountDefault)

--- a/workloads/workload_feature_store
+++ b/workloads/workload_feature_store
@@ -1,0 +1,116 @@
+# Feature-store workload: entity-major online serving.
+#
+# Models the same layout as the redis-benchmarks-specification playbook
+# "memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features":
+# https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features-template.yml
+#
+#   - ENTITY-MAJOR storage: each entity is one record (a Redis hash / a Mongo
+#     document) holding all of that entity's feature values, keyed
+#     <keyprefix><entity-id>.
+#   - Each record holds 50 numbered feature fields (feature_1..feature_50)
+#     plus one trailing event_ts metadata field: 51 fields total.
+#   - Field values are realistic typed scalars, not opaque bytes - matching
+#     how feature stores actually represent a feature (Feast: INT32/INT64/
+#     FLOAT32/FLOAT64/BOOL/UNIX_TIMESTAMP; Featureform: Int/Float/Bool/
+#     Timestamp). By default: feature_N fields are a numeric mix (rates/
+#     scores in [0,1), bounded counts, booleans - see fieldvalueinteger*/
+#     fieldvaluefloat* below to tune the ranges), and event_ts is a real
+#     RFC3339 timestamp. Set fieldvaluetype=random / lastfieldvaluetype=
+#     (empty) to instead reproduce the reference spec's memtier
+#     --random-data byte-for-byte (opaque bytes, only SIZE matters, 8-24
+#     bytes via fieldlength/fieldlengthminimum below) - note the numeric
+#     default changes the resident memory footprint vs. the reference
+#     spec's ~17GB, since Redis listpack-encodes digit-only values as
+#     integers.
+#   - Whole-entity online serving read: one round-trip fetching every field
+#     (Redis: HGETALL; Mongo: findOne projecting all 51 field names, i.e.
+#     the whole document).
+#   - Whole-row feature materialization write: one round-trip writing every
+#     field (Redis: HSET key f1 v1 ... f51 v51; Mongo: $set of every field).
+#   - Read-dominated online serving, ~95:5 (HGETALL:HSET == 19:1), against a
+#     Zipfian-skewed key population (a "hot" subset of entities is served
+#     disproportionately more often, as in real online inference traffic).
+#
+# Works out of the box against any database adapter, since the field
+# generation this workload relies on (typed values, field naming) lives in
+# the DB-agnostic core workload - `redis` (redis.datatype=hash, the default)
+# gets a whole-entity HGETALL/HSET fast path (see db/redis/db.go's Read),
+# `mongodb` stores each entity as a document with no extra configuration
+# needed.
+#
+# Usage:
+#   ./bin/go-ycsb load redis   -P workloads/workload_feature_store -p redis.addr=127.0.0.1:6379
+#   ./bin/go-ycsb run  redis   -P workloads/workload_feature_store -p redis.addr=127.0.0.1:6379
+#   ./bin/go-ycsb load mongodb -P workloads/workload_feature_store -p mongodb.url="mongodb://127.0.0.1:27017/ycsb"
+#   ./bin/go-ycsb run  mongodb -P workloads/workload_feature_store -p mongodb.url="mongodb://127.0.0.1:27017/ycsb"
+#
+# Scale down recordcount/operationcount for a quick local smoke test, e.g.
+#   -p recordcount=100000 -p operationcount=1000000
+
+workload=core
+
+# One hash per entity: feature_store:user_features:entity:<id>
+table=feature_store
+keyprefix=user_features:entity:
+
+# 10M entities, matching the reference dataset. Lower for local testing.
+recordcount=10000000
+operationcount=10000000
+threadcount=25
+
+# Entity ids are assigned sequentially during Load (1, 2, 3, ...) rather
+# than hashed/scrambled, matching the reference preload's sequential
+# key-minimum/key-maximum walk.
+insertorder=ordered
+
+# 50 numbered feature fields (feature_1..feature_50) + a trailing event_ts
+# metadata field = 51 fields per entity.
+fieldcount=51
+fieldnameprefix=feature_
+fieldnamestartindex=1
+lastfieldname=event_ts
+
+# Only used when fieldvaluetype=random (see below): 8-24 byte values,
+# matching memtier's --data-size-range=8-24.
+fieldlength=24
+fieldlengthminimum=8
+fieldlengthdistribution=uniform
+
+# Value content: feature_N fields get a realistic numeric (int/float/bool)
+# mix shaped like real Feast/Featureform feature values, and event_ts gets
+# a real RFC3339 timestamp.
+fieldvaluetype=numeric
+lastfieldvaluetype=timestamp
+
+# Tune the numeric ranges/precision to match your own features, e.g. a
+# bounded count column instead of the [0,100000] default:
+#fieldvalueintegermin=0
+#fieldvalueintegermax=100000
+#fieldvaluefloatmin=0.0
+#fieldvaluefloatmax=1.0
+#fieldvaluefloatprecision=4
+
+# To instead reproduce the reference spec exactly (opaque random bytes,
+# only SIZE matters), uncomment:
+#fieldvaluetype=random
+#lastfieldvaluetype=
+
+# Whole-entity serving: HGETALL / full-document read, HSET-all-fields /
+# full-document write - never a single-field read or partial update.
+readallfields=true
+writeallfields=true
+
+# Read-dominated online serving, ~95:5 (HGETALL:HSET ratio 19:1).
+readproportion=0.95
+updateproportion=0.05
+insertproportion=0
+scanproportion=0
+readmodifywriteproportion=0
+
+# Serving traffic favors a hot subset of entities, as in real online
+# inference load, rather than hitting the whole keyspace uniformly.
+requestdistribution=zipfian
+
+# Redis-specific: entity-major hash storage (the layout this workload
+# models). Ignored by other databases.
+redis.datatype=hash


### PR DESCRIPTION
## Summary

Adds `workloads/workload_feature_store`, modeling the entity-major online-serving layout used by feature stores (Feast, Featureform, Tecton-style systems): one record per entity holding many named feature fields, a whole-entity read/write access pattern, and a read-heavy, Zipfian-skewed request mix - based on the [redis-benchmarks-specification's feature-store playbook](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-playbook-feature-store-hash-10M-entities-50-features-template.yml).

Two things the existing core workload couldn't express, both added as generic properties usable by any workload file, not just this one:

- **Field naming**: `fieldnameprefix`/`fieldnamestartindex`/`lastfieldname`, so generated field names can look like `feature_1`..`feature_50` plus a trailing `event_ts`, instead of always `field0`..`fieldN`.
- **Field value CONTENT, not just size**: `fieldvaluetype=numeric/integer/float/boolean/timestamp` (plus `lastfieldvaluetype`, and min/max/precision knobs) generates realistic typed scalars - matching how a feature store actually represents a feature (Feast: `INT32`/`INT64`/`FLOAT32`/`FLOAT64`/`BOOL`/`UNIX_TIMESTAMP`) - instead of opaque random bytes. `fieldvaluetype=random` (the default) is unchanged/backward compatible - existing workload files are unaffected.

Also gives `db/redis/db.go`'s `Read` a whole-entity `HGETALL` fast path (when reading all fields of a hash, matching this workload's access pattern) instead of always enumerating every field name via `HMGET`.


## Test plan

- [x] `go build ./...`
- [x] Verified against a real Redis: `load` + `run` pass, and the underlying generated data reads back correctly (typed values, custom field names, and the new `HGETALL` fast path) via a manual smoke test.
- [x] `go test ./pkg/workload/...` (pre-existing `open workloads/workloadc` test failure is unrelated - reproduces identically on unmodified `master`)